### PR TITLE
Add dependabot auto updates

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,11 @@
+- match:
+    dependency_type: all
+    update_type: security:minor # includes patch updates!
+
+- match:
+    dependency_type: development
+    update_type: semver:minor # includes patch updates!
+
+- match:
+    dependency_type: production
+    update_type: semver:patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: UTC
+    labels:
+      - dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,15 @@
+name: Dependabot Automerge Check
+on:
+  - pull_request_target
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Automerge dependabot dependencies
+        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          github-token: ${{ secrets.OPENHPI_BOT_TOKEN }}


### PR DESCRIPTION
This PR adds automatic dependency updates to Poseidon using [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates).