### PR TITLE
Performance of the file copy

### DIFF
--- a/internal/nomad/api_querier.go
+++ b/internal/nomad/api_querier.go
@@ -91,6 +91,7 @@ func (nc *nomadAPIClient) Execute(runnerID string,
 	ctx context.Context, command []string, tty bool,
 	stdin io.Reader, stdout, stderr io.Writer,
 ) (int, error) {
+	log.Debug("Before fetching Allocations")
 	allocations, _, err := nc.client.Jobs().Allocations(runnerID, false, nil)
 	if err != nil {
 		return 1, fmt.Errorf("error retrieving allocations for runner: %w", err)
@@ -98,14 +99,17 @@ func (nc *nomadAPIClient) Execute(runnerID string,
 	if len(allocations) == 0 {
 		return 1, ErrorNoAllocationFound
 	}
+	log.Debug("Before fetching Info about allocation")
 	allocation, _, err := nc.client.Allocations().Info(allocations[0].ID, nil)
 	if err != nil {
 		return 1, fmt.Errorf("error retrieving allocation info: %w", err)
 	}
+	log.Debug("Before executing in allocation")
 	exitCode, err := nc.client.Allocations().Exec(ctx, allocation, TaskName, tty, command, stdin, stdout, stderr, nil, nil)
 	if err != nil {
 		return 1, fmt.Errorf("error executing command in allocation: %w", err)
 	}
+	log.Debug("After executing in allocation")
 	return exitCode, nil
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -144,6 +144,7 @@ func (r *NomadJob) ExecuteInteractively(
 }
 
 func (r *NomadJob) UpdateFileSystem(copyRequest *dto.UpdateFileSystemRequest) error {
+	log.Debug("Before UpdateFileSystem")
 	r.ResetTimeout()
 
 	var tarBuffer bytes.Buffer
@@ -156,8 +157,10 @@ func (r *NomadJob) UpdateFileSystem(copyRequest *dto.UpdateFileSystemRequest) er
 	updateFileCommand := (&dto.ExecutionRequest{Command: fileDeletionCommand + copyCommand}).FullCommand()
 	stdOut := bytes.Buffer{}
 	stdErr := bytes.Buffer{}
+	log.Debug("Before ExecuteCommand")
 	exitCode, err := r.api.ExecuteCommand(r.id, context.Background(), updateFileCommand, false,
 		&tarBuffer, &stdOut, &stdErr)
+	log.Debug("After ExecuteCommand")
 
 	if err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
The following are two execution logs of the File Copy process.
```
time="2021-10-22T16:19:33.467959Z" level=debug msg="Before UpdateFileSystem" package=runner
time="2021-10-22T16:19:33.468005Z" level=debug msg="Before ExecuteCommand" package=runner
time="2021-10-22T16:19:33.468014Z" level=debug msg="Before fetching Allocations" package=nomad
time="2021-10-22T16:19:33.565683Z" level=debug msg="Before fetching Info about allocation" package=nomad
time="2021-10-22T16:19:33.654211Z" level=debug msg="Before executing in allocation" package=nomad
time="2021-10-22T16:19:34.070807Z" level=debug msg="After executing in allocation" package=nomad
time="2021-10-22T16:19:34.070842Z" level=debug msg="After ExecuteCommand" package=runner
time="2021-10-22T16:19:34.070863Z" level=debug code=204 duration=602.977863ms method=PATCH path=/api/v1/runners/10-a3723825-3340-11ec-9b4e-8c8caab4d49a/files user_agent=PostmanRuntime/7.28.4
```

```
time="2021-10-22T16:25:40.730183Z" level=debug code=200 duration="113.003µs" method=POST path=/api/v1/runners user_agent=PostmanRuntime/7.28.4
time="2021-10-22T16:25:42.783385Z" level=debug msg="Runner started" id=10-ef013367-3343-11ec-89eb-8c8caab4d49a package=runner
time="2021-10-22T16:25:54.208628Z" level=debug msg="Before UpdateFileSystem" package=runner
time="2021-10-22T16:25:54.208668Z" level=debug msg="Before ExecuteCommand" package=runner
time="2021-10-22T16:25:54.208677Z" level=debug msg="Before fetching Allocations" package=nomad
time="2021-10-22T16:25:54.295403Z" level=debug msg="Before fetching Info about allocation" package=nomad
time="2021-10-22T16:25:54.383728Z" level=debug msg="Before executing in allocation" package=nomad
time="2021-10-22T16:25:54.837629Z" level=debug msg="After executing in allocation" package=nomad
time="2021-10-22T16:25:54.837688Z" level=debug msg="After ExecuteCommand" package=runner
time="2021-10-22T16:25:54.837726Z" level=debug code=204 duration=629.181328ms method=PATCH path=/api/v1/runners/10-776f23f2-3341-11ec-9b4e-8c8caab4d49a/files user_agent=PostmanRuntime/7.28.4
```
The file copy process consists of three requests to Nomad.
First, all allocations of the runner are loaded, then all information about the essential allocation is loaded and only then can the Exec command of the Go Library be executed.
I see a good chance that we can save the first two requests by keeping a reference to the Nomad object. (In the case of Poseidon's Execute Route, this even has twice the influence.)
But if we look at the logs, we see that the first two requests take only 175 ms, while the third request takes 454 ms. So for 70 per cent of the duration, I see little potential for savings.