### PR TITLE
Close evaluation stream for Nomad Job creation

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -136,7 +136,9 @@ func (a *APIClient) LoadRunnerJobs(environmentID dto.EnvironmentID) ([]*nomadApi
 	return jobs, occurredError
 }
 
-func (a *APIClient) MonitorEvaluation(evaluationID string, ctx context.Context) error {
+func (a *APIClient) MonitorEvaluation(evaluationID string, outerContext context.Context) error {
+	ctx, cancel := context.WithCancel(outerContext)
+	defer cancel()
 	stream, err := a.apiQuerier.EvaluationStream(evaluationID, ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving evaluation stream: %w", err)

--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -168,7 +168,8 @@ func asynchronouslyMonitorEvaluation(stream chan *nomadApi.Events) chan error {
 	readOnlyStream := func() <-chan *nomadApi.Events { return stream }()
 
 	apiMock := &apiQuerierMock{}
-	apiMock.On("EvaluationStream", mock.AnythingOfType("string"), ctx).Return(readOnlyStream, nil)
+	apiMock.On("EvaluationStream", mock.AnythingOfType("string"), mock.AnythingOfType("*context.cancelCtx")).
+		Return(readOnlyStream, nil)
 	apiClient := &APIClient{apiMock}
 
 	errChan := make(chan error)
@@ -195,7 +196,7 @@ func TestApiClient_MonitorEvaluationReturnsNilWhenStreamIsClosed(t *testing.T) {
 
 func TestApiClient_MonitorEvaluationReturnsErrorWhenStreamReturnsError(t *testing.T) {
 	apiMock := &apiQuerierMock{}
-	apiMock.On("EvaluationStream", mock.AnythingOfType("string"), mock.AnythingOfType("*context.emptyCtx")).
+	apiMock.On("EvaluationStream", mock.AnythingOfType("string"), mock.AnythingOfType("*context.cancelCtx")).
 		Return(nil, tests.ErrDefault)
 	apiClient := &APIClient{apiMock}
 	err := apiClient.MonitorEvaluation("id", context.Background())


### PR DESCRIPTION
 when set event handler have been finished.
This partially fixes #22.