### PR TITLE
Update versions used during GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
 
 env:
-  NOMAD_VERSION: 1.1.2
+  GO_VERSION: 1.17
+  NOMAD_VERSION: 1.1.6
 
 jobs:
   compile:
@@ -19,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -54,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -98,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - name: Cache Go modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This MR will use the latest versions for Go and Nomad in our GitHub actions pipeline.