### PR TITLE
Update last trim for Go build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Update last trim for Go build cache
+        # Go usually trims all builds not used for at least five days. We simulate that the last trim just occurred recently.
+        # Otherwise, the cache restored in the previous step would not be used for the build resulting in a longer workflow run.
+        # More details: https://github.com/golang/go/blob/d60ad1e068263832c711aaf17b6ccb1b7f71b000/src/cmd/go/internal/cache/cache.go#L255-L326
+        run: date +%s > ~/.cache/go-build/trim.txt
       - name: Build
         run: make build
       - name: Upload Poseidon binary
@@ -63,6 +68,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Update last trim for Go build cache
+        # Go usually trims all builds not used for at least five days. We simulate that the last trim just occurred recently.
+        # Otherwise, the cache restored in the previous step would not be used for the build resulting in a longer workflow run.
+        # More details: https://github.com/golang/go/blob/d60ad1e068263832c711aaf17b6ccb1b7f71b000/src/cmd/go/internal/cache/cache.go#L255-L326
+        run: date +%s > ~/.cache/go-build/trim.txt
       - name: Run tests
         run: make coverhtml
       - name: Upload coverage report
@@ -108,6 +118,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Update last trim for Go build cache
+        # Go usually trims all builds not used for at least five days. We simulate that the last trim just occurred recently.
+        # Otherwise, the cache restored in the previous step would not be used for the build resulting in a longer workflow run.
+        # More details: https://github.com/golang/go/blob/d60ad1e068263832c711aaf17b6ccb1b7f71b000/src/cmd/go/internal/cache/cache.go#L255-L326
+        run: date +%s > ~/.cache/go-build/trim.txt
       - name: Cache Nomad binary
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This MR will ensure that we use the build cache optimally. During some investigations I figured out that the `make run` command was [very fast](https://github.com/openHPI/poseidon/runs/3862540112?check_suite_focus=true) sometimes and [a bit slower](https://github.com/openHPI/poseidon/runs/3961669088?check_suite_focus=true) in other occasions. It turns out that this behavior is linked to the automatic cache cleanup (according to the [documentation](https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching)):

> The go command periodically deletes cached data that has not been used recently. After even more research, I was able to confirm that the timespan are [five days](https://github.com/golang/go/blob/d60ad1e068263832c711aaf17b6ccb1b7f71b000/src/cmd/go/internal/cache/cache.go#L255-L326).

As we use the hash of the go.sum file, this is not reflected:

https://github.com/openHPI/poseidon/blob/ac6ce56c38922d561c55814f6d2c23facb8491e2/.github/workflows/ci.yml#L28

Therefore, this PR updates the trim time stamp that Go uses to evaluate the recent usage. It enables us to reuse the cache we stored earlier without pushing a new cache after every build.