### PR TITLE
Make environment variables of the system accessible.

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -278,7 +278,7 @@ paths:
                   type: string
                   example: python exercise.py
                 environment:
-                  description: Environment variables for this execution. The keys of this object are the variable names and the value of each key is the value of the variable with the same name
+                  description: Environment variables for this execution. The keys of this object are the variable names and the value of each key is the value of the variable with the same name. The environment variables of the system remain accessible.
                   type: object
                   additionalProperties:
                     type: string

--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -24,7 +24,7 @@ type ExecutionRequest struct {
 
 func (er *ExecutionRequest) FullCommand() []string {
 	command := make([]string, 0)
-	command = append(command, "env", "-")
+	command = append(command, "env")
 	for variable, value := range er.Environment {
 		command = append(command, fmt.Sprintf("%s=%s", variable, value))
 	}


### PR DESCRIPTION
Closes #27

The simplest solution for Issue #27 would be to make all environment variables of the system available (as implemented in this merge request).
The question remains, however, whether this is always the intention. So far, Poseidon's approach has been to make only those environment variables accessible that are declared in the execute request.
A way in between would be that only if the environment variable, e.g. "showSystemEnvironmentVariables" (or an HTTP query parameter) is set to "true", all system variables are available.