### PR TITLE
Add guard close in event stream

### DIFF
--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -261,6 +261,10 @@ func (m *NomadRunnerManager) onAllocationAdded(alloc *nomadApi.Allocation) {
 func (m *NomadRunnerManager) onAllocationStopped(alloc *nomadApi.Allocation) {
 	log.WithField("id", alloc.JobID).Debug("Runner stopped")
 
+	if nomad.IsEnvironmentTemplateID(alloc.JobID) {
+		return
+	}
+
 	environmentID, err := nomad.EnvironmentIDFromRunnerID(alloc.JobID)
 	if err != nil {
 		log.WithError(err).Warn("Stopped allocation can not be handled")


### PR DESCRIPTION
Closes #29
... for not handling stopped Execution Environment Allocations.