### PR TITLE
Change response logging message

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -66,7 +66,7 @@ func (writer *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, erro
 	return conn, rw, nil
 }
 
-// HTTPLoggingMiddleware returns an http.Handler that logs different information about every request.
+// HTTPLoggingMiddleware returns a http.Handler that logs different information about every request.
 func HTTPLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now().UTC()
@@ -84,7 +84,7 @@ func HTTPLoggingMiddleware(next http.Handler) http.Handler {
 			"user_agent": r.UserAgent(),
 		})
 		if lrw.statusCode >= http.StatusInternalServerError {
-			logEntry.Warn()
+			logEntry.Error("Failing " + path)
 		} else {
 			logEntry.Debug()
 		}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -28,7 +28,7 @@ func TestHTTPMiddlewareWarnsWhenInternalServerError(t *testing.T) {
 	HTTPLoggingMiddleware(mockHTTPStatusHandler(500)).ServeHTTP(recorder, request)
 
 	assert.Equal(t, 1, len(hook.Entries))
-	assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 }
 
 func TestHTTPMiddlewareDebugsWhenStatusOK(t *testing.T) {


### PR DESCRIPTION
to allow specific error tracking in sentry. 

[See POSEIDON-F](https://sentry.io/share/issue/a943340c963747c19ce31b8611788a18/)

Otherwise all failing responses would be merged to one Sentry issue.