### PR TITLE
Unwrap Nomad Error for Allocation Exec

### DIFF
--- a/internal/nomad/api_querier_test.go
+++ b/internal/nomad/api_querier_test.go
@@ -1,0 +1,18 @@
+package nomad
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWebsocketErrorNeedsToBeUnwrapped(t *testing.T) {
+	rawError := &websocket.CloseError{Code: websocket.CloseNormalClosure}
+	err := fmt.Errorf("websocket closed before receiving exit code: %w", rawError)
+
+	assert.False(t, websocket.IsCloseError(err, websocket.CloseNormalClosure))
+	rootCause := errors.Unwrap(err)
+	assert.True(t, websocket.IsCloseError(rootCause, websocket.CloseNormalClosure))
+}


### PR DESCRIPTION
As #44 is still not fixed, I investigated further and think we need to unwrap the error before inspecting the close cause. Hence, this MR will allow us to inspect whether the WebSocket connection was closed normally by unwrapping the error first.

Sentry:
```
error executing command in allocation: websocket closed before receiving exit code: websocket: close 1000 (normal)
```

We see at least two wrapped errors in Sentry:

Poseidon:
https://github.com/openHPI/poseidon/blob/ebbbfdb9befe98062276f4f815dc6465b7435ea5/internal/nomad/api_querier.go#L109

[Nomad](https://github.com/hashicorp/nomad/blob/e694000f4674139ab5d25607f5c8b16af3e4e0ac/api/allocations_exec.go#L206):
```go
errCh <- fmt.Errorf("websocket closed before receiving exit code: %w", err)
```

The outer one is added after the check, while the inner one is added through Nomad.