### PR TITLE
Recreate runners on execution environment update

### DIFF
--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -437,7 +437,7 @@ func newRunnerWithNotMockedRunnerManager(t *testing.T, apiMock *nomad.ExecutorAP
 	require.NoError(t, err)
 	e.SetID(eID)
 	e.SetPrewarmingPoolSize(0)
-	runnerManager.SetEnvironment(e)
+	runnerManager.StoreEnvironment(e)
 	e.AddRunner(runnerJob)
 
 	r, err = runnerManager.Claim(e.ID(), int(tests.DefaultTestTimeout.Seconds()))

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -110,8 +110,10 @@ func TestRegisterFailsWhenNomadJobRegistrationFails(t *testing.T) {
 	expectedErr := tests.ErrDefault
 
 	apiClientMock.On("RegisterNomadJob", mock.AnythingOfType("*api.Job")).Return("", expectedErr)
+	apiClientMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	apiClientMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 
-	environment := &NomadEnvironment{"", &nomadApi.Job{}, nil}
+	environment := &NomadEnvironment{"", &nomadApi.Job{}, runner.NewLocalRunnerStorage()}
 	environment.SetID(tests.DefaultEnvironmentIDAsInteger)
 	err := environment.Register(apiClientMock)
 
@@ -125,8 +127,10 @@ func TestRegisterTemplateJobSucceedsWhenMonitoringEvaluationSucceeds(t *testing.
 
 	apiClientMock.On("RegisterNomadJob", mock.AnythingOfType("*api.Job")).Return(evaluationID, nil)
 	apiClientMock.On("MonitorEvaluation", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+	apiClientMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	apiClientMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 
-	environment := &NomadEnvironment{"", &nomadApi.Job{}, nil}
+	environment := &NomadEnvironment{"", &nomadApi.Job{}, runner.NewLocalRunnerStorage()}
 	environment.SetID(tests.DefaultEnvironmentIDAsInteger)
 	err := environment.Register(apiClientMock)
 
@@ -139,8 +143,10 @@ func TestRegisterTemplateJobReturnsErrorWhenMonitoringEvaluationFails(t *testing
 
 	apiClientMock.On("RegisterNomadJob", mock.AnythingOfType("*api.Job")).Return(evaluationID, nil)
 	apiClientMock.On("MonitorEvaluation", mock.AnythingOfType("string"), mock.Anything).Return(tests.ErrDefault)
+	apiClientMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	apiClientMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 
-	environment := &NomadEnvironment{"", &nomadApi.Job{}, nil}
+	environment := &NomadEnvironment{"", &nomadApi.Job{}, runner.NewLocalRunnerStorage()}
 	environment.SetID(tests.DefaultEnvironmentIDAsInteger)
 	err := environment.Register(apiClientMock)
 

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestConfigureNetworkCreatesNewNetworkWhenNoNetworkExists(t *testing.T) {
 	_, job := helpers.CreateTemplateJob()
-	defaultTaskGroup := nomad.FindOrCreateDefaultTaskGroup(job)
+	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
 	environment := &NomadEnvironment{"", job, nil}
 
 	if assert.Equal(t, 0, len(defaultTaskGroup.Networks)) {
@@ -28,7 +28,7 @@ func TestConfigureNetworkCreatesNewNetworkWhenNoNetworkExists(t *testing.T) {
 
 func TestConfigureNetworkDoesNotCreateNewNetworkWhenNetworkExists(t *testing.T) {
 	_, job := helpers.CreateTemplateJob()
-	defaultTaskGroup := nomad.FindOrCreateDefaultTaskGroup(job)
+	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
 	environment := &NomadEnvironment{"", job, nil}
 
 	networkResource := &nomadApi.NetworkResource{Mode: "bridge"}
@@ -44,8 +44,8 @@ func TestConfigureNetworkDoesNotCreateNewNetworkWhenNetworkExists(t *testing.T) 
 
 func TestConfigureNetworkSetsCorrectValues(t *testing.T) {
 	_, job := helpers.CreateTemplateJob()
-	defaultTaskGroup := nomad.FindOrCreateDefaultTaskGroup(job)
-	defaultTask := nomad.FindOrCreateDefaultTask(defaultTaskGroup)
+	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
+	defaultTask := nomad.FindAndValidateDefaultTask(defaultTaskGroup)
 
 	mode, ok := defaultTask.Config["network_mode"]
 	assert.True(t, ok)
@@ -56,8 +56,8 @@ func TestConfigureNetworkSetsCorrectValues(t *testing.T) {
 	t.Run("with no network access", func(t *testing.T) {
 		for _, ports := range exposedPortsTests {
 			_, testJob := helpers.CreateTemplateJob()
-			testTaskGroup := nomad.FindOrCreateDefaultTaskGroup(testJob)
-			testTask := nomad.FindOrCreateDefaultTask(testTaskGroup)
+			testTaskGroup := nomad.FindAndValidateDefaultTaskGroup(testJob)
+			testTask := nomad.FindAndValidateDefaultTask(testTaskGroup)
 			testEnvironment := &NomadEnvironment{"", job, nil}
 
 			testEnvironment.SetNetworkAccess(false, ports)
@@ -71,8 +71,8 @@ func TestConfigureNetworkSetsCorrectValues(t *testing.T) {
 	t.Run("with network access", func(t *testing.T) {
 		for _, ports := range exposedPortsTests {
 			_, testJob := helpers.CreateTemplateJob()
-			testTaskGroup := nomad.FindOrCreateDefaultTaskGroup(testJob)
-			testTask := nomad.FindOrCreateDefaultTask(testTaskGroup)
+			testTaskGroup := nomad.FindAndValidateDefaultTaskGroup(testJob)
+			testTask := nomad.FindAndValidateDefaultTask(testTaskGroup)
 			testEnvironment := &NomadEnvironment{"", testJob, nil}
 
 			testEnvironment.SetNetworkAccess(true, ports)
@@ -197,8 +197,8 @@ func TestSampleDoesNotSetForcePullFlag(t *testing.T) {
 		job, ok := args.Get(0).(*nomadApi.Job)
 		assert.True(t, ok)
 
-		taskGroup := nomad.FindOrCreateDefaultTaskGroup(job)
-		task := nomad.FindOrCreateDefaultTask(taskGroup)
+		taskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
+		task := nomad.FindAndValidateDefaultTask(taskGroup)
 		assert.False(t, task.Config["force_pull"].(bool))
 
 		call.ReturnArguments = mock.Arguments{nil}

--- a/internal/environment/manager.go
+++ b/internal/environment/manager.go
@@ -134,10 +134,6 @@ func (m *NomadEnvironmentManager) CreateOrUpdate(id dto.EnvironmentID, request d
 	if err != nil {
 		return false, fmt.Errorf("error registering template job in API: %w", err)
 	}
-	err = environment.UpdateRunnerSpecs(m.api)
-	if err != nil {
-		return false, fmt.Errorf("error updating runner jobs in API: %w", err)
-	}
 	err = environment.Scale(m.api)
 	if err != nil {
 		return false, fmt.Errorf("error scaling template job in API: %w", err)

--- a/internal/environment/manager.go
+++ b/internal/environment/manager.go
@@ -178,7 +178,7 @@ func (m *NomadEnvironmentManager) Load() error {
 			jobLogger.Info("Job not running, skipping ...")
 			continue
 		}
-		configTaskGroup := nomad.FindOrCreateConfigTaskGroup(job)
+		configTaskGroup := nomad.FindAndValidateConfigTaskGroup(job)
 		if configTaskGroup == nil {
 			jobLogger.Info("Couldn't find config task group in job, skipping ...")
 			continue

--- a/internal/environment/manager_test.go
+++ b/internal/environment/manager_test.go
@@ -79,8 +79,8 @@ func (s *CreateOrUpdateTestSuite) TestCreateOrUpdatesSetsForcePullFlag() {
 
 		// The environment job itself has not the force_pull flag
 		if count > 1 {
-			taskGroup := nomad.FindOrCreateDefaultTaskGroup(job)
-			task := nomad.FindOrCreateDefaultTask(taskGroup)
+			taskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
+			task := nomad.FindAndValidateDefaultTask(taskGroup)
 			s.True(task.Config["force_pull"].(bool))
 		}
 

--- a/internal/environment/manager_test.go
+++ b/internal/environment/manager_test.go
@@ -54,6 +54,8 @@ func (s *CreateOrUpdateTestSuite) SetupTest() {
 
 func (s *CreateOrUpdateTestSuite) TestReturnsErrorIfCreatesOrUpdateEnvironmentReturnsError() {
 	s.apiMock.On("RegisterNomadJob", mock.AnythingOfType("*api.Job")).Return("", tests.ErrDefault)
+	s.apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	s.apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	s.runnerManagerMock.On("GetEnvironment", mock.AnythingOfType("dto.EnvironmentID")).Return(nil, false)
 	s.runnerManagerMock.On("SetEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
 	_, err := s.manager.CreateOrUpdate(dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger), s.request)
@@ -62,6 +64,8 @@ func (s *CreateOrUpdateTestSuite) TestReturnsErrorIfCreatesOrUpdateEnvironmentRe
 
 func (s *CreateOrUpdateTestSuite) TestCreateOrUpdatesSetsForcePullFlag() {
 	s.apiMock.On("RegisterNomadJob", mock.AnythingOfType("*api.Job")).Return("", nil)
+	s.apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	s.apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	s.runnerManagerMock.On("GetEnvironment", mock.AnythingOfType("dto.EnvironmentID")).Return(nil, false)
 	s.runnerManagerMock.On("SetEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
 	s.apiMock.On("MonitorEvaluation", mock.AnythingOfType("string"), mock.Anything).Return(nil)
@@ -131,6 +135,8 @@ func TestNewNomadEnvironmentManager(t *testing.T) {
 func TestNomadEnvironmentManager_Get(t *testing.T) {
 	apiMock := &nomad.ExecutorAPIMock{}
 	mockWatchAllocations(apiMock)
+	apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
+	apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	call := apiMock.On("LoadEnvironmentJobs")
 	call.Run(func(args mock.Arguments) {
 		call.ReturnArguments = mock.Arguments{[]*nomadApi.Job{}, nil}

--- a/internal/environment/manager_test.go
+++ b/internal/environment/manager_test.go
@@ -57,7 +57,7 @@ func (s *CreateOrUpdateTestSuite) TestReturnsErrorIfCreatesOrUpdateEnvironmentRe
 	s.apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
 	s.apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	s.runnerManagerMock.On("GetEnvironment", mock.AnythingOfType("dto.EnvironmentID")).Return(nil, false)
-	s.runnerManagerMock.On("SetEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
+	s.runnerManagerMock.On("StoreEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
 	_, err := s.manager.CreateOrUpdate(dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger), s.request)
 	s.ErrorIs(err, tests.ErrDefault)
 }
@@ -67,7 +67,7 @@ func (s *CreateOrUpdateTestSuite) TestCreateOrUpdatesSetsForcePullFlag() {
 	s.apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
 	s.apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	s.runnerManagerMock.On("GetEnvironment", mock.AnythingOfType("dto.EnvironmentID")).Return(nil, false)
-	s.runnerManagerMock.On("SetEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
+	s.runnerManagerMock.On("StoreEnvironment", mock.AnythingOfType("*environment.NomadEnvironment")).Return(true)
 	s.apiMock.On("MonitorEvaluation", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	s.apiMock.On("LoadRunnerIDs", mock.AnythingOfType("string")).Return([]string{}, nil)
 	call := s.apiMock.On("RegisterRunnerJob", mock.AnythingOfType("*api.Job"))
@@ -155,7 +155,7 @@ func TestNomadEnvironmentManager_Get(t *testing.T) {
 		expectedEnvironment, err := NewNomadEnvironment(templateEnvironmentJobHCL)
 		expectedEnvironment.SetID(tests.DefaultEnvironmentIDAsInteger)
 		require.NoError(t, err)
-		runnerManager.SetEnvironment(expectedEnvironment)
+		runnerManager.StoreEnvironment(expectedEnvironment)
 
 		environment, err := m.Get(tests.DefaultEnvironmentIDAsInteger, false)
 		assert.NoError(t, err)
@@ -181,7 +181,7 @@ func TestNomadEnvironmentManager_Get(t *testing.T) {
 			localEnvironment, err := NewNomadEnvironment(templateEnvironmentJobHCL)
 			require.NoError(t, err)
 			localEnvironment.SetID(tests.DefaultEnvironmentIDAsInteger)
-			runnerManager.SetEnvironment(localEnvironment)
+			runnerManager.StoreEnvironment(localEnvironment)
 
 			environment, err := m.Get(tests.DefaultEnvironmentIDAsInteger, false)
 			assert.NoError(t, err)
@@ -234,7 +234,7 @@ func TestNomadEnvironmentManager_List(t *testing.T) {
 		localEnvironment, err := NewNomadEnvironment(templateEnvironmentJobHCL)
 		require.NoError(t, err)
 		localEnvironment.SetID(tests.DefaultEnvironmentIDAsInteger)
-		runnerManager.SetEnvironment(localEnvironment)
+		runnerManager.StoreEnvironment(localEnvironment)
 
 		environments, err := m.List(false)
 		assert.NoError(t, err)

--- a/internal/nomad/job_test.go
+++ b/internal/nomad/job_test.go
@@ -24,7 +24,7 @@ func TestFindTaskGroup(t *testing.T) {
 func TestFindOrCreateDefaultTask(t *testing.T) {
 	t.Run("Adds default task group when not set", func(t *testing.T) {
 		job := &nomadApi.Job{}
-		group := FindOrCreateDefaultTaskGroup(job)
+		group := FindAndValidateDefaultTaskGroup(job)
 		assert.NotNil(t, group)
 		assert.Equal(t, TaskGroupName, *group.Name)
 		assert.Equal(t, 1, len(job.TaskGroups))
@@ -38,7 +38,7 @@ func TestFindOrCreateDefaultTask(t *testing.T) {
 		expectedGroup := &nomadApi.TaskGroup{Name: &groupName}
 		job.TaskGroups = []*nomadApi.TaskGroup{expectedGroup}
 
-		group := FindOrCreateDefaultTaskGroup(job)
+		group := FindAndValidateDefaultTaskGroup(job)
 		assert.NotNil(t, group)
 		assert.Equal(t, 1, len(job.TaskGroups))
 		assert.Equal(t, expectedGroup, group)
@@ -48,7 +48,7 @@ func TestFindOrCreateDefaultTask(t *testing.T) {
 func TestFindOrCreateConfigTaskGroup(t *testing.T) {
 	t.Run("Adds config task group when not set", func(t *testing.T) {
 		job := &nomadApi.Job{}
-		group := FindOrCreateConfigTaskGroup(job)
+		group := FindAndValidateConfigTaskGroup(job)
 		assert.NotNil(t, group)
 		assert.Equal(t, group, job.TaskGroups[0])
 		assert.Equal(t, 1, len(job.TaskGroups))
@@ -63,7 +63,7 @@ func TestFindOrCreateConfigTaskGroup(t *testing.T) {
 		expectedGroup := &nomadApi.TaskGroup{Name: &groupName}
 		job.TaskGroups = []*nomadApi.TaskGroup{expectedGroup}
 
-		group := FindOrCreateConfigTaskGroup(job)
+		group := FindAndValidateConfigTaskGroup(job)
 		assert.NotNil(t, group)
 		assert.Equal(t, 1, len(job.TaskGroups))
 		assert.Equal(t, expectedGroup, group)
@@ -77,7 +77,7 @@ func TestFindOrCreateTask(t *testing.T) {
 		expectedTask := &nomadApi.Task{Name: TaskName}
 		group.Tasks = []*nomadApi.Task{expectedTask}
 
-		task := FindOrCreateDefaultTask(group)
+		task := FindAndValidateDefaultTask(group)
 		assert.NotNil(t, task)
 		assert.Equal(t, 1, len(group.Tasks))
 		assert.Equal(t, expectedTask, task)
@@ -89,7 +89,7 @@ func TestFindOrCreateTask(t *testing.T) {
 		expectedTask := &nomadApi.Task{Name: ConfigTaskName}
 		group.Tasks = []*nomadApi.Task{expectedTask}
 
-		task := FindOrCreateConfigTask(group)
+		task := FindAndValidateConfigTask(group)
 		assert.NotNil(t, task)
 		assert.Equal(t, 1, len(group.Tasks))
 		assert.Equal(t, expectedTask, task)

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -39,7 +39,7 @@ type ExecutorAPI interface {
 	// LoadRunnerJobs loads all runner jobs specific for the environment.
 	LoadRunnerJobs(environmentID dto.EnvironmentID) ([]*nomadApi.Job, error)
 
-	// LoadRunnerIDs returns the IDs of all runners with the specified id prefix which are running and not about to
+	// LoadRunnerIDs returns the IDs of all runners with the specified id prefix which are not about to
 	// get stopped.
 	LoadRunnerIDs(prefix string) (runnerIds []string, err error)
 
@@ -101,8 +101,8 @@ func (a *APIClient) LoadRunnerIDs(prefix string) (runnerIDs []string, err error)
 		return nil, err
 	}
 	for _, jobListStub := range list {
-		allocationRunning := jobListStub.JobSummary.Summary[TaskGroupName].Running > 0
-		if jobListStub.Status == structs.JobStatusRunning && allocationRunning {
+		// Filter out dead ("complete", "failed" or "lost") jobs
+		if jobListStub.Status != structs.JobStatusDead {
 			runnerIDs = append(runnerIDs, jobListStub.ID)
 		}
 	}

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -311,7 +311,7 @@ func (a *APIClient) MarkRunnerAsUsed(runnerID string, duration int) error {
 	if err != nil {
 		return fmt.Errorf("couldn't retrieve job info: %w", err)
 	}
-	configTaskGroup := FindOrCreateConfigTaskGroup(job)
+	configTaskGroup := FindAndValidateConfigTaskGroup(job)
 	configTaskGroup.Meta[ConfigMetaUsedKey] = ConfigMetaUsedValue
 	configTaskGroup.Meta[ConfigMetaTimeoutKey] = strconv.Itoa(duration)
 

--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -86,13 +86,14 @@ func (s *LoadRunnersTestSuite) TestAvailableRunnerIsReturned() {
 	s.Equal(s.availableRunner.ID, returnedIds[0])
 }
 
-func (s *LoadRunnersTestSuite) TestPendingRunnerIsNotReturned() {
+func (s *LoadRunnersTestSuite) TestPendingRunnerIsReturned() {
 	s.mock.On("listJobs", mock.AnythingOfType("string")).
 		Return([]*nomadApi.JobListStub{s.pendingRunner}, nil)
 
 	returnedIds, err := s.nomadAPIClient.LoadRunnerIDs(s.jobID)
 	s.Require().NoError(err)
-	s.Empty(returnedIds)
+	s.Len(returnedIds, 1)
+	s.Equal(s.pendingRunner.ID, returnedIds[0])
 }
 
 func (s *LoadRunnersTestSuite) TestDeadRunnerIsNotReturned() {
@@ -116,9 +117,11 @@ func (s *LoadRunnersTestSuite) TestReturnsAllAvailableRunners() {
 
 	returnedIds, err := s.nomadAPIClient.LoadRunnerIDs(s.jobID)
 	s.Require().NoError(err)
-	s.Len(returnedIds, 2)
+	s.Len(returnedIds, 3)
 	s.Contains(returnedIds, s.availableRunner.ID)
 	s.Contains(returnedIds, s.anotherAvailableRunner.ID)
+	s.Contains(returnedIds, s.pendingRunner.ID)
+	s.NotContains(returnedIds, s.deadRunner.ID)
 }
 
 const TestNamespace = "unit-tests"

--- a/internal/runner/execution_environment_mock.go
+++ b/internal/runner/execution_environment_mock.go
@@ -19,6 +19,20 @@ func (_m *ExecutionEnvironmentMock) AddRunner(r Runner) {
 	_m.Called(r)
 }
 
+// ApplyPrewarmingPoolSize provides a mock function with given fields: apiClient
+func (_m *ExecutionEnvironmentMock) ApplyPrewarmingPoolSize(apiClient nomad.ExecutorAPI) error {
+	ret := _m.Called(apiClient)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(nomad.ExecutorAPI) error); ok {
+		r0 = rf(apiClient)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CPULimit provides a mock function with given fields:
 func (_m *ExecutionEnvironmentMock) CPULimit() uint {
 	ret := _m.Called()
@@ -205,20 +219,6 @@ func (_m *ExecutionEnvironmentMock) Sample(apiClient nomad.ExecutorAPI) (Runner,
 	return r0, r1
 }
 
-// Scale provides a mock function with given fields: apiClient
-func (_m *ExecutionEnvironmentMock) Scale(apiClient nomad.ExecutorAPI) error {
-	ret := _m.Called(apiClient)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(nomad.ExecutorAPI) error); ok {
-		r0 = rf(apiClient)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // SetCPULimit provides a mock function with given fields: limit
 func (_m *ExecutionEnvironmentMock) SetCPULimit(limit uint) {
 	_m.Called(limit)
@@ -252,18 +252,4 @@ func (_m *ExecutionEnvironmentMock) SetNetworkAccess(allow bool, ports []uint16)
 // SetPrewarmingPoolSize provides a mock function with given fields: count
 func (_m *ExecutionEnvironmentMock) SetPrewarmingPoolSize(count uint) {
 	_m.Called(count)
-}
-
-// UpdateRunnerSpecs provides a mock function with given fields: apiClient
-func (_m *ExecutionEnvironmentMock) UpdateRunnerSpecs(apiClient nomad.ExecutorAPI) error {
-	ret := _m.Called(apiClient)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(nomad.ExecutorAPI) error); ok {
-		r0 = rf(apiClient)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }

--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -52,8 +52,6 @@ type ExecutionEnvironment interface {
 	Delete(apiClient nomad.ExecutorAPI) error
 	// Scale manages if the executor has enough idle runner according to the PrewarmingPoolSize.
 	Scale(apiClient nomad.ExecutorAPI) error
-	// UpdateRunnerSpecs updates all Runner of the passed environment to have the same definition as the environment.
-	UpdateRunnerSpecs(apiClient nomad.ExecutorAPI) error
 
 	// Sample returns and removes an arbitrary available runner.
 	// ok is true iff a runner was returned.

--- a/internal/runner/manager_mock.go
+++ b/internal/runner/manager_mock.go
@@ -137,16 +137,7 @@ func (_m *ManagerMock) Return(r Runner) error {
 	return r0
 }
 
-// SetEnvironment provides a mock function with given fields: environment
-func (_m *ManagerMock) SetEnvironment(environment ExecutionEnvironment) bool {
-	ret := _m.Called(environment)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(ExecutionEnvironment) bool); ok {
-		r0 = rf(environment)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
+// StoreEnvironment provides a mock function with given fields: environment
+func (_m *ManagerMock) StoreEnvironment(environment ExecutionEnvironment) {
+	_m.Called(environment)
 }

--- a/internal/runner/manager_test.go
+++ b/internal/runner/manager_test.go
@@ -82,8 +82,7 @@ func mockIdleRunners(environmentMock *ExecutionEnvironmentMock) {
 
 func (s *ManagerTestSuite) setDefaultEnvironment() {
 	s.exerciseEnvironment.On("ID").Return(defaultEnvironmentID)
-	created := s.nomadRunnerManager.SetEnvironment(s.exerciseEnvironment)
-	s.Require().True(created)
+	s.nomadRunnerManager.StoreEnvironment(s.exerciseEnvironment)
 }
 
 func (s *ManagerTestSuite) waitForRunnerRefresh() {
@@ -93,8 +92,7 @@ func (s *ManagerTestSuite) waitForRunnerRefresh() {
 func (s *ManagerTestSuite) TestSetEnvironmentAddsNewEnvironment() {
 	anotherEnvironment := &ExecutionEnvironmentMock{}
 	anotherEnvironment.On("ID").Return(anotherEnvironmentID)
-	created := s.nomadRunnerManager.SetEnvironment(anotherEnvironment)
-	s.Require().True(created)
+	s.nomadRunnerManager.StoreEnvironment(anotherEnvironment)
 
 	job, ok := s.nomadRunnerManager.environments.Get(anotherEnvironmentID)
 	s.True(ok)

--- a/internal/runner/storage.go
+++ b/internal/runner/storage.go
@@ -21,6 +21,9 @@ type Storage interface {
 	// It does nothing if no runner with the id is present in the store.
 	Delete(id string)
 
+	// Purge removes all runners from the storage.
+	Purge()
+
 	// Length returns the number of currently stored runners in the storage.
 	Length() int
 
@@ -70,6 +73,12 @@ func (s *localRunnerStorage) Delete(id string) {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.runners, id)
+}
+
+func (s *localRunnerStorage) Purge() {
+	s.Lock()
+	defer s.Unlock()
+	s.runners = make(map[string]Runner)
 }
 
 func (s *localRunnerStorage) Sample() (Runner, bool) {


### PR DESCRIPTION
Closes #69

Too many runners are created because the existing runners are updated. During the update, there is a short time window in which the runner is not available. Since we cannot wait completely for the update, the scaling process is already started, which, due to the runners just restarting, calculates the number of runners needed incorrectly and creates too many. By removing the update process, the cause of the miscalculation is removed.

Closes #48

We require Nomad to re-fetch the Docker image every time the environment is updated. So far, this is done by changing the jobHCL. However, we only do this once and therefore the new image is no longer loaded with the second update. By restarting the runners with each update of the execution environment, the latest Docker image is always loaded.
