### PR TITLE
Improve documentation for Network support in Nomad

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,3 +51,13 @@ limits {
     http_max_conns_per_client = 0
 }
 ```
+
+### Enable Networking Support in Nomad
+
+In order to allow full networking support in Nomad, the `containernetworking-plugins` are required on the host. They can be either installed manually or through a package manager. In the latter case, the installation path might differ. Hence, add the following line to the `client` directive of the Nomad configuration in `/etc/nomad.d/client.hcl`:
+
+```hcl
+    cni_path = "/usr/lib/cni"
+```
+
+If the path is not set up correctly or the dependency is missing, the following error will be shown in Nomad: `failed to find plugin "bridge" in path [/opt/cni/bin]`

--- a/docs/resources/client.example.hcl
+++ b/docs/resources/client.example.hcl
@@ -4,6 +4,7 @@ client {
         "server domain 1",
         "server domain 2"
     ]
+    cni_path = "/usr/lib/cni"
 }
 
 plugin "docker" {


### PR DESCRIPTION
In order to prevent the issue mentioned in #78, an improved documentation would be helpful. Therefore, this PR adds a documentation on the dependency that needs to be added to all Nomad agents in order to enable network support.

(It's Murphy's law that each PR I open has failing unit tests, e2e tests and Trivy scan results. But why?!)