### PR TITLE
Update default image in template-environment-job.hcl

### DIFF
--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -29,7 +29,7 @@ job "template-0" {
       kill_signal = "SIGKILL"
 
       config {
-        image = "drp.codemoon.xopic.de/openhpi/co_execenv_python:3.8"
+        image = "openhpi/docker_exec_phusion"
         command = "sleep"
         args = ["infinity"]
         network_mode = "none"


### PR DESCRIPTION
This MR changes the default image used in the `template-environment-job.hcl`:

* The image previously used is not available publicly and not maintained any longer
* The new base image is not bound to any specific programming environment

The change should not have any large impact as the image is overwritten anyway. I just thought of updating this (invalid) reference.