### PR TITLE
Add a warning when allocations fail

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -238,6 +238,10 @@ func handleEvaluationEvent(evaluations map[string]chan error, event *nomadApi.Ev
 			case <-time.After(resultChannelWriteTimeout):
 				log.WithField("eval", eval).Error("Full evaluation channel")
 			}
+		} else if eval.TriggeredBy == "alloc-failure" {
+			log.WithField("job", eval.JobID).
+				WithField("eval", eval).
+				Warn("Allocation failure")
 		}
 	}
 	return nil


### PR DESCRIPTION
I have added the filter for `TriggeredBy` so that not every execution produces a log statement ;) Now every failed allocation should produce two log statements as Nomad retries to place the allocation.

Closes #78 