### PR TITLE
Run Sentry release GitHub Action

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,17 @@
+name: Create a Sentry release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}


### PR DESCRIPTION
on every push to main.

Closes #53 

The added GitHub Action notifies Sentry about the new release and related commits.

Closes #55

The deploy/ansible-deployment (changed to [299b18](https://gitlab.hpi.de/maximilian.pass/poseidon-deployment/-/commit/299b18282520a4aa75354d5c36df2d20a113abac)) now just makes a deployment notification and not a release notification.