### PR TITLE
Add trace statements for WebSocket messages

### DIFF
--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -117,6 +117,8 @@ func handleInput(messageType int, reader io.Reader, err error, buffer chan byte,
 		log.WithError(err).Warn("error while reading WebSocket message")
 		return true
 	}
+
+	log.WithField("message", string(message)).Trace("Received message from client")
 	for _, character := range message {
 		select {
 		case <-ctx.Done():
@@ -298,6 +300,7 @@ func (wp *webSocketProxy) sendToClient(message dto.WebSocketMessage) error {
 		wp.closeWithError("Error creating message")
 		return fmt.Errorf("error marshaling WebSocket message: %w", err)
 	}
+	log.WithField("message", message).Trace("Sending message to client")
 	err = wp.writeMessage(websocket.TextMessage, encodedMessage)
 	if err != nil {
 		errorMessage := "Error writing the message"


### PR DESCRIPTION
This MR adds the first messages for the most detailed log level available (the TRACE level). It is intended to debug application responsiveness in case of delays within the WebSocket connection. Therefore, each WebSocket message is logged with the corresponding timestamp. 

Due to the excessive logging of raw data, this log level is not recommended for production use but rather for local development.