### PR TITLE
Fix typo in configuration.example.yaml

### DIFF
--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -75,6 +75,6 @@ influxdb:
   # The token to secure the influxdb endpoint.
   token: SecretBase64Token==
   # The organisation set in your influxdb configuration.
-  organisation: PoseidonOrg
+  organization: PoseidonOrg
   # The influxdb bucket to store the data in.
   bucket: poseidon

--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -74,7 +74,7 @@ influxdb:
   url: http://localhost:8086
   # The token to secure the influxdb endpoint.
   token: SecretBase64Token==
-  # The organisation set in your influxdb configuration.
+  # The organization set in your influxdb configuration.
   organization: PoseidonOrg
   # The influxdb bucket to store the data in.
   bucket: poseidon


### PR DESCRIPTION
Unfortunately, this led to two additional production Poseidon restarts.