### PR TITLE
Ignore Comments in Makefiles starting with #

### DIFF
--- a/deploy/aws/java11Exec/src/main/java/poseidon/SimpleMakefile.java
+++ b/deploy/aws/java11Exec/src/main/java/poseidon/SimpleMakefile.java
@@ -68,6 +68,8 @@ class SimpleMakefile {
             String[] trimmedCommands = Arrays.stream(ruleCommands)
                     .map(String::trim)
                     .map(s -> s.startsWith("@") ? s.substring(1) : s)
+                    .map(s -> s.contains("#") ? s.substring(0, s.indexOf("#")) : s)
+                    .filter(s -> !s.isEmpty())
                     .toArray(String[]::new);
 
             rules.put(ruleName, trimmedCommands);

--- a/deploy/aws/java11Exec/src/test/java/poseidon/SimpleMakefileTest.java
+++ b/deploy/aws/java11Exec/src/test/java/poseidon/SimpleMakefileTest.java
@@ -37,6 +37,13 @@ public class SimpleMakefileTest {
                   "\t@java org/example/RecursiveMath\r\n"
           ).getBytes(StandardCharsets.UTF_8));
 
+  static final String SuccessfulMakefileWithComment = Base64.getEncoder().encodeToString(
+          ("run:\r\n" +
+                  "\t@javac org/example/RecursiveMath.java\r\n" +
+                  "\t@java org/example/RecursiveMath\r\n" +
+                  "\t#exit\r\n"
+          ).getBytes(StandardCharsets.UTF_8));
+
   static final String NotSupportedMakefile = Base64.getEncoder().encodeToString(
           ("run: test\n" +
                   "\tjavac org/example/RecursiveMath.java\n" +
@@ -61,6 +68,13 @@ public class SimpleMakefileTest {
   @Test
   public void sucessfullMakeWithAtSymbol() {
     parseRunCommandOfMakefile(SuccessfulMakefileWithAtSymbol);
+  }
+
+  // We remove [any comments with #](https://www.gnu.org/software/make/manual/make.html#Recipe-Syntax)
+  // as they are normally ignored / echoed with most shells.
+  @Test
+  public void sucessfullMakeWithComment() {
+    parseRunCommandOfMakefile(SuccessfulMakefileWithComment);
   }
 
   private void parseRunCommandOfMakefile(String makefileB64) {


### PR DESCRIPTION
Some existing Makefiles in CodeOcean still have a trailing `#exit` in recipes, which we need to ignore.

This MR is based on #118.