### PR TITLE
Add Grafana Dashboard

### DIFF
--- a/cmd/poseidon/main.go
+++ b/cmd/poseidon/main.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"github.com/getsentry/sentry-go"
-	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
-	influxdb2API "github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/openHPI/poseidon/internal/api"
 	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/internal/environment"
 	"github.com/openHPI/poseidon/internal/nomad"
 	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/pkg/logging"
+	"github.com/openHPI/poseidon/pkg/monitoring"
 	"net/http"
 	"os"
 	"os/signal"
@@ -35,20 +34,6 @@ func shutdownSentry() {
 		sentry.CurrentHub().Recover(err)
 		sentry.Flush(logging.GracefulSentryShutdown)
 	}
-}
-
-func initInfluxDB(db *config.InfluxDB) (writeAPI influxdb2API.WriteAPI, cancel func()) {
-	if db.URL == "" {
-		return nil, func() {}
-	}
-
-	client := influxdb2.NewClient(db.URL, db.Token)
-	writeAPI = client.WriteAPI(db.Organization, db.Bucket)
-	cancel = func() {
-		writeAPI.Flush()
-		client.Close()
-	}
-	return writeAPI, cancel
 }
 
 func runServer(server *http.Server) {
@@ -111,7 +96,7 @@ func createAWSManager() (runnerManager runner.Manager, environmentManager enviro
 }
 
 // initServer builds the http server and configures it with the chain of responsibility for multiple managers.
-func initServer(influxClient influxdb2API.WriteAPI) *http.Server {
+func initServer() *http.Server {
 	runnerManager, environmentManager := createManagerHandler(createNomadManager, config.Config.Nomad.Enabled,
 		nil, nil)
 	runnerManager, environmentManager = createManagerHandler(createAWSManager, config.Config.AWS.Enabled,
@@ -121,7 +106,7 @@ func initServer(influxClient influxdb2API.WriteAPI) *http.Server {
 		Addr:        config.Config.Server.URL().Host,
 		ReadTimeout: time.Second * 15,
 		IdleTimeout: time.Second * 60,
-		Handler:     api.NewRouter(runnerManager, environmentManager, influxClient),
+		Handler:     api.NewRouter(runnerManager, environmentManager),
 	}
 }
 
@@ -149,10 +134,10 @@ func main() {
 	initSentry(&config.Config.Sentry)
 	defer shutdownSentry()
 
-	influxDB, cancel := initInfluxDB(&config.Config.InfluxDB)
+	cancel := monitoring.InitializeInfluxDB(&config.Config.InfluxDB)
 	defer cancel()
 
-	server := initServer(influxDB)
+	server := initServer()
 	go runServer(server)
 	shutdownOnOSSignal(server)
 }

--- a/deploy/grafana-dashboard/main.json
+++ b/deploy/grafana-dashboard/main.json
@@ -1,0 +1,991 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 13,
+  "iteration": 1653418538534,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 25,
+      "panels": [],
+      "title": "General",
+      "type": "row"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 28,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "8.4.6",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean)\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 1,
+        "format": "ns",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: (tables=<-, column) => tables |> quantile(q: 0.999))\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Service time (99.9%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "all"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r._field == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"status\"])\n\nall = data |> set(key: \"status\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-green",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1000000000
+              },
+              {
+                "color": "yellow",
+                "value": 2000000000
+              },
+              {
+                "color": "#EF843C",
+                "value": 3000000000
+              },
+              {
+                "color": "light-red",
+                "value": 4000000000
+              },
+              {
+                "color": "dark-red",
+                "value": 5000000000
+              },
+              {
+                "color": "dark-purple",
+                "value": 10000000000
+              },
+              {
+                "color": "#000000",
+                "value": 20000000000
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 20,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_field\", \"environment_type\", \"status\", \"_measurement\"])\n  |> group(columns: [\"environment_id\", \"runner_id\"])\n  |> mean()\n  |> group(columns: [\"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Execution duration",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 32,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> rename(columns: {_value: \"env\"})\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions per runner",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "super-light-green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 26,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_measurement\", \"_field\", \"environment_type\", \"runner_id\", \"status\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value / 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions per minute",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Runner Insights",
+      "type": "row"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 0,
+        "y": 22
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 29,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "8.4.6",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_time\", \"_start\", \"_stop\", \"_value\", \"environment_id\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Execution duration",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 1,
+        "format": "ns",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 10,
+        "y": 22
+      },
+      "id": 18,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "import \"date\"\n\nresult = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n\nif int(v: v.windowPeriod) > int(v: 1m)\n  then result |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: true) \n  else result\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions per minute",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 14,
+        "y": 22
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions per minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 10,
+        "y": 29
+      },
+      "id": 31,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Execution duration",
+      "type": "gauge"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 0,
+        "y": 32
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 33,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "8.4.6",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "data = from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n\nrunner_deletions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_deleteRunner\")\n  |> keep(columns: [\"_time\", \"runner_id\"])\n\nexecutions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n\njoin(tables: {key1: executions, key2: runner_deletions}, on: [\"runner_id\"], method: \"inner\")\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions per runner",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "none",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "cMBTRmQnz"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 14,
+        "y": 32
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_provideRunner\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+          "refId": "A"
+        }
+      ],
+      "title": "Runner per minute",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "10",
+            "32"
+          ],
+          "value": [
+            "10",
+            "32"
+          ]
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "cMBTRmQnz"
+        },
+        "definition": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> keep(columns: [\"environment_id\"])\n  |> distinct(column: \"environment_id\")\n  |> keep(columns: [\"_value\"])\n",
+        "description": "All environments currently tracked by Poseidon",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Environment IDs",
+        "multi": true,
+        "name": "environment_ids",
+        "options": [],
+        "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> keep(columns: [\"environment_id\"])\n  |> distinct(column: \"environment_id\")\n  |> keep(columns: [\"_value\"])\n",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "cMBTRmQnz"
+        },
+        "definition": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> keep(columns: [\"status\"])\n  |> distinct(column: \"status\")\n  |> keep(columns: [\"_value\"])\n",
+        "description": "The http status code of the Poseidon response.",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Status Code",
+        "multi": true,
+        "name": "status_codes",
+        "options": [],
+        "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> keep(columns: [\"status\"])\n  |> distinct(column: \"status\")\n  |> keep(columns: [\"_value\"])\n",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Poseidon",
+  "uid": "hQRzR1Qnz",
+  "version": 15,
+  "weekStart": ""
+}

--- a/deploy/grafana-dashboard/main.json
+++ b/deploy/grafana-dashboard/main.json
@@ -22,12 +22,12 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 13,
-  "iteration": 1653418538534,
+  "iteration": 1653418538550,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -35,461 +35,881 @@
         "y": 0
       },
       "id": 25,
-      "panels": [],
+      "panels": [
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 28,
+          "legend": {
+            "show": false
+          },
+          "pluginVersion": "8.4.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean)\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Request Latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "decimals": 1,
+            "format": "ns",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 27,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: (tables=<-, column) => tables |> quantile(q: 0.999))\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Service time (99.9%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "all"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "super-light-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r._field == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"status\"])\n\nall = data |> set(key: \"status\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+              "refId": "A"
+            }
+          ],
+          "title": "Requests per minute",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "super-light-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1000000000
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 2000000000
+                  },
+                  {
+                    "color": "#EF843C",
+                    "value": 3000000000
+                  },
+                  {
+                    "color": "light-red",
+                    "value": 4000000000
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 5000000000
+                  },
+                  {
+                    "color": "dark-purple",
+                    "value": 10000000000
+                  },
+                  {
+                    "color": "#000000",
+                    "value": 20000000000
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 8,
+            "x": 0,
+            "y": 10
+          },
+          "id": 20,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_field\", \"environment_type\", \"status\", \"_measurement\"])\n  |> group(columns: [\"environment_id\", \"runner_id\"])\n  |> mean()\n  |> group(columns: [\"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution duration",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-RdYlGr"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "super-light-green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 8,
+            "x": 8,
+            "y": 10
+          },
+          "id": 32,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> rename(columns: {_value: \"env\"})\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Executions per runner",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-GrYlRd"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "super-light-green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 8,
+            "x": 16,
+            "y": 10
+          },
+          "id": 26,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_measurement\", \"_field\", \"environment_type\", \"runner_id\", \"status\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value / 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Executions per minute",
+          "type": "bargauge"
+        }
+      ],
       "title": "General",
       "type": "row"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "timeseries",
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
+      "collapsed": true,
       "gridPos": {
-        "h": 9,
-        "w": 8,
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 1
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 28,
-      "legend": {
-        "show": false
-      },
-      "pluginVersion": "8.4.6",
-      "reverseYBuckets": false,
-      "targets": [
+      "id": 23,
+      "panels": [
+        {
+          "cards": {},
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 0,
+            "y": 2
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 29,
+          "legend": {
+            "show": false
+          },
+          "pluginVersion": "8.4.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_time\", \"_start\", \"_stop\", \"_value\", \"environment_id\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Execution duration",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "decimals": 1,
+            "format": "ns",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
+        },
         {
           "datasource": {
             "type": "influxdb",
             "uid": "cMBTRmQnz"
           },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean)\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Request Latency",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 1,
-        "format": "ns",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 10,
-              "type": "log"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-GrYlRd"
               },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
           },
-          "unit": "ns"
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 10,
+            "y": 2
+          },
+          "id": 18,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": true,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "import \"date\"\n\nresult = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n\nif int(v: v.windowPeriod) > int(v: 1m)\n  then result |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: true) \n  else result\n",
+              "refId": "A"
+            }
+          ],
+          "title": "Executions per minute",
+          "type": "gauge"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 1
-      },
-      "id": 27,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "cMBTRmQnz"
           },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"_measurement\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: (tables=<-, column) => tables |> quantile(q: 0.999))\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Service time (99.9%)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "log"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
               },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "all"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-green",
-                  "mode": "fixed"
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
                 }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 1
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
           },
-          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r._field == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_time\", \"_value\", \"status\"])\n\nall = data |> set(key: \"status\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
-          "refId": "A"
-        }
-      ],
-      "title": "Requests per minute",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 14,
+            "y": 2
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-green",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1000000000
-              },
-              {
-                "color": "yellow",
-                "value": 2000000000
-              },
-              {
-                "color": "#EF843C",
-                "value": 3000000000
-              },
-              {
-                "color": "light-red",
-                "value": 4000000000
-              },
-              {
-                "color": "dark-red",
-                "value": 5000000000
-              },
-              {
-                "color": "dark-purple",
-                "value": 10000000000
-              },
-              {
-                "color": "#000000",
-                "value": 20000000000
-              }
-            ]
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 0,
-        "y": 10
-      },
-      "id": 20,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": true
+          "title": "Executions per minute",
+          "type": "timeseries"
         },
-        "showUnfilled": true
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "cMBTRmQnz"
           },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_field\", \"environment_type\", \"status\", \"_measurement\"])\n  |> group(columns: [\"environment_id\", \"runner_id\"])\n  |> mean()\n  |> group(columns: [\"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Execution duration",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-RdYlGr"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-GrYlRd"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ns"
+            },
+            "overrides": []
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-green",
-                "value": null
-              }
-            ]
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 10,
+            "y": 9
           },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 8,
-        "y": 10
-      },
-      "id": 32,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "id": 31,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": true
+          "title": "Execution duration",
+          "type": "gauge"
         },
-        "showUnfilled": true
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
         {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => exists r.environment_id)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> rename(columns: {_value: \"env\"})\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Executions per runner",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "fieldConfig": {
-        "defaults": {
+          "cards": {},
           "color": {
-            "mode": "continuous-GrYlRd"
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
           },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-green",
-                "value": null
-              }
-            ]
+          "dataFormat": "timeseries",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "cMBTRmQnz"
           },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 16,
-        "y": 10
-      },
-      "id": 26,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "description": "",
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 0,
+            "y": 12
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 33,
+          "legend": {
+            "show": false
+          },
+          "pluginVersion": "8.4.6",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "data = from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n\nrunner_deletions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_deleteRunner\")\n  |> keep(columns: [\"_time\", \"runner_id\"])\n\nexecutions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n\njoin(tables: {key1: executions, key2: runner_deletions}, on: [\"runner_id\"], method: \"inner\")\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n",
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": true
+          "title": "Executions per runner",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "yAxis": {
+            "format": "none",
+            "logBase": 1,
+            "show": true
+          },
+          "yBucketBound": "auto"
         },
-        "showUnfilled": true
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
         {
           "datasource": {
             "type": "influxdb",
             "uid": "cMBTRmQnz"
           },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> drop(columns: [\"_measurement\", \"_field\", \"environment_type\", \"runner_id\", \"status\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> keep(columns: [\"_value\", \"environment_id\"])\n  |> mean()\n  |> map(fn: (r) => ({r with _value: r._value / 3.0})) // Each execution has three requests\n  |> rename(columns: {_value: \"env\"})\n",
-          "refId": "A"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 14,
+            "y": 12
+          },
+          "id": 30,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.4.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "influxdb",
+                "uid": "cMBTRmQnz"
+              },
+              "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_provideRunner\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+              "refId": "A"
+            }
+          ],
+          "title": "Runner per minute",
+          "type": "timeseries"
         }
       ],
-      "title": "Executions per minute",
-      "type": "bargauge"
+      "title": "Runner Insights",
+      "type": "row"
     },
     {
       "collapsed": false,
@@ -497,128 +917,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 2
       },
-      "id": 23,
+      "id": 36,
       "panels": [],
-      "title": "Runner Insights",
+      "title": "Availability",
       "type": "row"
     },
     {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "timeseries",
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
-      "gridPos": {
-        "h": 10,
-        "w": 10,
-        "x": 0,
-        "y": 22
-      },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 29,
-      "legend": {
-        "show": false
-      },
-      "pluginVersion": "8.4.6",
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_time\", \"_start\", \"_stop\", \"_value\", \"environment_id\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Execution duration",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "decimals": 1,
-        "format": "ns",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 10,
-        "y": 22
-      },
-      "id": 18,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": true,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "import \"date\"\n\nresult = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\"])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n\nif int(v: v.windowPeriod) > int(v: 1m)\n  then result |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: true) \n  else result\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Executions per minute",
-      "type": "gauge"
-    },
-    {
       "datasource": {
         "type": "influxdb",
         "uid": "cMBTRmQnz"
@@ -676,214 +982,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 10,
-        "x": 14,
-        "y": 22
-      },
-      "id": 21,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
-          "refId": "A"
-        }
-      ],
-      "title": "Executions per minute",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ns"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 10,
-        "y": 29
-      },
-      "id": 31,
-      "options": {
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "pluginVersion": "8.4.6",
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/execute\" or r[\"_measurement\"] == \"poseidon_/files\" or r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> filter(fn: (r) => exists r.environment_id)\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean, createEmpty: false)\n  |> map(fn: (r) => ({r with _value: r._value * 3.0})) // Each execution has three requests\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Execution duration",
-      "type": "gauge"
-    },
-    {
-      "cards": {},
-      "color": {
-        "cardColor": "#b4ff00",
-        "colorScale": "sqrt",
-        "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
-        "mode": "spectrum"
-      },
-      "dataFormat": "timeseries",
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
-      "gridPos": {
-        "h": 10,
-        "w": 10,
+        "h": 11,
+        "w": 24,
         "x": 0,
-        "y": 32
+        "y": 3
       },
-      "heatmap": {},
-      "hideZeroBuckets": false,
-      "highlightCards": true,
-      "id": 33,
-      "legend": {
-        "show": false
-      },
-      "pluginVersion": "8.4.6",
-      "reverseYBuckets": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "cMBTRmQnz"
-          },
-          "query": "data = from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n\nrunner_deletions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_deleteRunner\")\n  |> keep(columns: [\"_time\", \"runner_id\"])\n\nexecutions = data\n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_/websocket\")\n  |> keep(columns: [\"_value\", \"environment_id\", \"runner_id\"])\n  |> count()\n\njoin(tables: {key1: executions, key2: runner_deletions}, on: [\"runner_id\"], method: \"inner\")\n  |> keep(columns: [\"_value\", \"_time\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Executions per runner",
-      "tooltip": {
-        "show": true,
-        "showHistogram": false
-      },
-      "type": "heatmap",
-      "xAxis": {
-        "show": true
-      },
-      "yAxis": {
-        "format": "none",
-        "logBase": 1,
-        "show": true
-      },
-      "yBucketBound": "auto"
-    },
-    {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "cMBTRmQnz"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 10,
-        "x": 14,
-        "y": 32
-      },
-      "id": 30,
+      "id": 34,
       "options": {
         "legend": {
           "calcs": [],
@@ -902,11 +1006,11 @@
             "type": "influxdb",
             "uid": "cMBTRmQnz"
           },
-          "query": "import \"date\"\n\ndata = from(bucket: \"poseidon/autogen\")\n  |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))\n  |> filter(fn: (r) => r[\"_field\"] == \"duration\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))  \n  |> filter(fn: (r) => r[\"_measurement\"] == \"poseidon_provideRunner\")\n  |> keep(columns: [\"_time\", \"_value\", \"environment_id\"])\n\nall = data |> set(key: \"environment_id\", value: \"all\")\n\nunion(tables: [data, all])\n  |> aggregateWindow(every: 1m, fn: count, createEmpty: true)\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 20), fn: mean, createEmpty: true) \n",
+          "query": "from(bucket: \"poseidon/autogen\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_field\"] == \"idle_runner\" or r[\"_field\"] == \"prewarming_pool_size\")\n  |> filter(fn: (r) => contains(value: r[\"environment_id\"], set: ${environment_ids:json}))\n  |> filter(fn: (r) => contains(value: r[\"status\"], set: ${status_codes:json}))\n  |> keep(columns: [\"_field\", \"_value\", \"_time\", \"environment_id\"])\n  |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: mean)\n",
           "refId": "A"
         }
       ],
-      "title": "Runner per minute",
+      "title": "Prewarming Poolsize and idle Runner",
       "type": "timeseries"
     }
   ],
@@ -918,14 +1022,12 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
-            "10",
-            "32"
+            "All"
           ],
           "value": [
-            "10",
-            "32"
+            "$__all"
           ]
         },
         "datasource": {
@@ -949,7 +1051,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -986,6 +1088,6 @@
   "timezone": "",
   "title": "Poseidon",
   "uid": "hQRzR1Qnz",
-  "version": 15,
+  "version": 16,
   "weekStart": ""
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/gorilla/mux"
-	influxdb2API "github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/openHPI/poseidon/internal/api/auth"
 	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/internal/environment"
@@ -29,14 +28,13 @@ const (
 // always returns a router for the newest version of our API. We
 // use gorilla/mux because it is more convenient than net/http, e.g.
 // when extracting path parameters.
-func NewRouter(runnerManager runner.Manager, environmentManager environment.ManagerHandler,
-	influxClient influxdb2API.WriteAPI) *mux.Router {
+func NewRouter(runnerManager runner.Manager, environmentManager environment.ManagerHandler) *mux.Router {
 	router := mux.NewRouter()
 	// this can later be restricted to a specific host with
 	// `router.Host(...)` and to HTTPS with `router.Schemes("https")`
 	configureV1Router(router, runnerManager, environmentManager)
 	router.Use(logging.HTTPLoggingMiddleware)
-	router.Use(monitoring.InfluxDB2Middleware(influxClient, environmentManager))
+	router.Use(monitoring.InfluxDB2Middleware)
 	return router
 }
 

--- a/internal/api/environments_test.go
+++ b/internal/api/environments_test.go
@@ -31,7 +31,7 @@ func TestEnvironmentControllerTestSuite(t *testing.T) {
 
 func (s *EnvironmentControllerTestSuite) SetupTest() {
 	s.manager = &environment.ManagerHandlerMock{}
-	s.router = NewRouter(nil, s.manager, nil)
+	s.router = NewRouter(nil, s.manager)
 }
 
 func (s *EnvironmentControllerTestSuite) TestList() {

--- a/internal/api/runners.go
+++ b/internal/api/runners.go
@@ -68,7 +68,7 @@ func (r *RunnerController) provide(writer http.ResponseWriter, request *http.Req
 		}
 		return
 	}
-	monitoring.AddRunnerMonitoringData(request, nextRunner)
+	monitoring.AddRunnerMonitoringData(request, nextRunner.ID(), nextRunner.Environment())
 	sendJSON(writer, &dto.RunnerResponse{ID: nextRunner.ID(), MappedPorts: nextRunner.MappedPorts()}, http.StatusOK)
 }
 
@@ -82,7 +82,7 @@ func (r *RunnerController) updateFileSystem(writer http.ResponseWriter, request 
 	}
 
 	targetRunner, _ := runner.FromContext(request.Context())
-	monitoring.AddRunnerMonitoringData(request, targetRunner)
+	monitoring.AddRunnerMonitoringData(request, targetRunner.ID(), targetRunner.Environment())
 	if err := targetRunner.UpdateFileSystem(fileCopyRequest); err != nil {
 		log.WithError(err).Error("Could not perform the requested updateFileSystem.")
 		writeInternalServerError(writer, err, dto.ErrorUnknown)
@@ -108,7 +108,7 @@ func (r *RunnerController) execute(writer http.ResponseWriter, request *http.Req
 		scheme = "ws"
 	}
 	targetRunner, _ := runner.FromContext(request.Context())
-	monitoring.AddRunnerMonitoringData(request, targetRunner)
+	monitoring.AddRunnerMonitoringData(request, targetRunner.ID(), targetRunner.Environment())
 
 	path, err := r.runnerRouter.Get(WebsocketPath).URL(RunnerIDKey, targetRunner.ID())
 	if err != nil {
@@ -160,7 +160,7 @@ func (r *RunnerController) findRunnerMiddleware(next http.Handler) http.Handler 
 // It destroys the given runner on the executor and removes it from the used runners list.
 func (r *RunnerController) delete(writer http.ResponseWriter, request *http.Request) {
 	targetRunner, _ := runner.FromContext(request.Context())
-	monitoring.AddRunnerMonitoringData(request, targetRunner)
+	monitoring.AddRunnerMonitoringData(request, targetRunner.ID(), targetRunner.Environment())
 
 	err := r.manager.Return(targetRunner)
 	if err != nil {

--- a/internal/api/runners_test.go
+++ b/internal/api/runners_test.go
@@ -107,7 +107,7 @@ type RunnerRouteTestSuite struct {
 
 func (s *RunnerRouteTestSuite) SetupTest() {
 	s.runnerManager = &runner.ManagerMock{}
-	s.router = NewRouter(s.runnerManager, nil, nil)
+	s.router = NewRouter(s.runnerManager, nil)
 	s.runner = runner.NewNomadJob("some-id", nil, nil, nil)
 	s.executionID = "execution"
 	s.runner.StoreExecution(s.executionID, &dto.ExecutionRequest{})

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -76,7 +76,7 @@ func (wp *webSocketProxy) waitForExit(exit <-chan runner.ExitInfo, cancelExecuti
 // connectToRunner is the endpoint for websocket connections.
 func (r *RunnerController) connectToRunner(writer http.ResponseWriter, request *http.Request) {
 	targetRunner, _ := runner.FromContext(request.Context())
-	monitoring.AddRunnerMonitoringData(request, targetRunner)
+	monitoring.AddRunnerMonitoringData(request, targetRunner.ID(), targetRunner.Environment())
 
 	executionID := request.URL.Query().Get(ExecutionIDKey)
 	if !targetRunner.ExecutionExists(executionID) {

--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -51,7 +51,7 @@ func (s *WebSocketTestSuite) SetupTest() {
 
 	runnerManager := &runner.ManagerMock{}
 	runnerManager.On("Get", s.runner.ID()).Return(s.runner, nil)
-	s.router = NewRouter(runnerManager, nil, nil)
+	s.router = NewRouter(runnerManager, nil)
 	s.server = httptest.NewServer(s.router)
 }
 
@@ -257,7 +257,7 @@ func TestWebsocketTLS(t *testing.T) {
 
 	runnerManager := &runner.ManagerMock{}
 	runnerManager.On("Get", r.ID()).Return(r, nil)
-	router := NewRouter(runnerManager, nil, nil)
+	router := NewRouter(runnerManager, nil)
 
 	server, err := helpers.StartTLSServer(t, router)
 	require.NoError(t, err)
@@ -327,7 +327,7 @@ func newRunnerWithNotMockedRunnerManager(t *testing.T, apiMock *nomad.ExecutorAP
 		call.ReturnArguments = mock.Arguments{nil}
 	})
 	runnerManager := runner.NewNomadRunnerManager(apiMock, context.Background())
-	router := NewRouter(runnerManager, nil, nil)
+	router := NewRouter(runnerManager, nil)
 	server := httptest.NewServer(router)
 
 	runnerID := tests.DefaultRunnerID

--- a/internal/environment/aws_environment.go
+++ b/internal/environment/aws_environment.go
@@ -87,7 +87,8 @@ func (a *AWSEnvironment) CPULimit() uint {
 func (a *AWSEnvironment) SetCPULimit(_ uint) {}
 
 func (a *AWSEnvironment) MemoryLimit() uint {
-	return 0
+	const memorySizeOfDeployedLambdaFunction = 2048 // configured /deploy/aws/template.yaml
+	return memorySizeOfDeployedLambdaFunction
 }
 
 func (a *AWSEnvironment) SetMemoryLimit(_ uint) {
@@ -95,7 +96,7 @@ func (a *AWSEnvironment) SetMemoryLimit(_ uint) {
 }
 
 func (a *AWSEnvironment) NetworkAccess() (enabled bool, mappedPorts []uint16) {
-	return false, nil
+	return true, nil
 }
 
 func (a *AWSEnvironment) SetNetworkAccess(_ bool, _ []uint16) {

--- a/internal/environment/aws_environment.go
+++ b/internal/environment/aws_environment.go
@@ -87,7 +87,7 @@ func (a *AWSEnvironment) CPULimit() uint {
 func (a *AWSEnvironment) SetCPULimit(_ uint) {}
 
 func (a *AWSEnvironment) MemoryLimit() uint {
-	panic("not supported")
+	return 0
 }
 
 func (a *AWSEnvironment) SetMemoryLimit(_ uint) {
@@ -95,7 +95,7 @@ func (a *AWSEnvironment) SetMemoryLimit(_ uint) {
 }
 
 func (a *AWSEnvironment) NetworkAccess() (enabled bool, mappedPorts []uint16) {
-	panic("not supported")
+	return false, nil
 }
 
 func (a *AWSEnvironment) SetNetworkAccess(_ bool, _ []uint16) {

--- a/internal/environment/nomad_manager.go
+++ b/internal/environment/nomad_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/pkg/logging"
+	"github.com/openHPI/poseidon/pkg/monitoring"
 	"github.com/openHPI/poseidon/pkg/storage"
 	"os"
 )
@@ -142,7 +143,7 @@ func (m *NomadEnvironmentManager) Load() error {
 			apiClient:   m.api,
 			jobHCL:      templateEnvironmentJobHCL,
 			job:         job,
-			idleRunners: storage.NewLocalStorage[runner.Runner](),
+			idleRunners: storage.NewMonitoredLocalStorage[runner.Runner](monitoring.MeasurementIdleRunnerNomad, nil),
 		}
 		m.runnerManager.StoreEnvironment(environment)
 		jobLogger.Info("Successfully recovered environment")
@@ -181,7 +182,7 @@ func fetchEnvironment(id dto.EnvironmentID, apiClient nomad.ExecutorAPI) (runner
 				apiClient:   apiClient,
 				jobHCL:      templateEnvironmentJobHCL,
 				job:         job,
-				idleRunners: storage.NewLocalStorage[runner.Runner](),
+				idleRunners: storage.NewMonitoredLocalStorage[runner.Runner](monitoring.MeasurementIdleRunnerNomad, nil),
 			}
 		}
 	}

--- a/internal/runner/abstract_manager.go
+++ b/internal/runner/abstract_manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/openHPI/poseidon/pkg/dto"
+	"github.com/openHPI/poseidon/pkg/monitoring"
 	"github.com/openHPI/poseidon/pkg/storage"
 )
 
@@ -21,8 +22,9 @@ type AbstractManager struct {
 // NewAbstractManager creates a new abstract runner manager that keeps track of all runners of one kind.
 func NewAbstractManager() *AbstractManager {
 	return &AbstractManager{
-		environments: storage.NewLocalStorage[ExecutionEnvironment](),
-		usedRunners:  storage.NewLocalStorage[Runner](),
+		environments: storage.NewMonitoredLocalStorage[ExecutionEnvironment](
+			monitoring.MeasurementEnvironments, monitorEnvironmentData),
+		usedRunners: storage.NewMonitoredLocalStorage[Runner](monitoring.MeasurementUsedRunner, nil),
 	}
 }
 

--- a/internal/runner/aws_manager_test.go
+++ b/internal/runner/aws_manager_test.go
@@ -14,8 +14,7 @@ func TestAWSRunnerManager_EnvironmentAccessor(t *testing.T) {
 	environments := m.ListEnvironments()
 	assert.Empty(t, environments)
 
-	environment := &ExecutionEnvironmentMock{}
-	environment.On("ID").Return(dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger))
+	environment := createBasicEnvironmentMock(defaultEnvironmentID)
 	m.StoreEnvironment(environment)
 
 	environments = m.ListEnvironments()
@@ -32,8 +31,7 @@ func TestAWSRunnerManager_EnvironmentAccessor(t *testing.T) {
 
 func TestAWSRunnerManager_Claim(t *testing.T) {
 	m := NewAWSRunnerManager()
-	environment := &ExecutionEnvironmentMock{}
-	environment.On("ID").Return(dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger))
+	environment := createBasicEnvironmentMock(defaultEnvironmentID)
 	r, err := NewAWSFunctionWorkload(environment, nil)
 	assert.NoError(t, err)
 	environment.On("Sample").Return(r, true)
@@ -59,8 +57,7 @@ func TestAWSRunnerManager_Claim(t *testing.T) {
 
 func TestAWSRunnerManager_Return(t *testing.T) {
 	m := NewAWSRunnerManager()
-	environment := &ExecutionEnvironmentMock{}
-	environment.On("ID").Return(dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger))
+	environment := createBasicEnvironmentMock(defaultEnvironmentID)
 	m.StoreEnvironment(environment)
 	r, err := NewAWSFunctionWorkload(environment, nil)
 	assert.NoError(t, err)
@@ -84,4 +81,14 @@ func TestAWSRunnerManager_Return(t *testing.T) {
 		assert.NoError(t, err)
 		nextHandler.AssertCalled(t, "Return", nonAWSRunner)
 	})
+}
+
+func createBasicEnvironmentMock(id dto.EnvironmentID) *ExecutionEnvironmentMock {
+	environment := &ExecutionEnvironmentMock{}
+	environment.On("ID").Return(id)
+	environment.On("Image").Return("")
+	environment.On("CPULimit").Return(uint(0))
+	environment.On("MemoryLimit").Return(uint(0))
+	environment.On("NetworkAccess").Return(false, nil)
+	return environment
 }

--- a/internal/runner/aws_runner.go
+++ b/internal/runner/aws_runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/pkg/execution"
+	"github.com/openHPI/poseidon/pkg/monitoring"
 	"github.com/openHPI/poseidon/pkg/storage"
 	"io"
 )
@@ -47,7 +48,7 @@ func NewAWSFunctionWorkload(
 	workload := &AWSFunctionWorkload{
 		id:                newUUID.String(),
 		fs:                make(map[dto.FilePath][]byte),
-		executions:        storage.NewLocalStorage[*dto.ExecutionRequest](),
+		executions:        storage.NewMonitoredLocalStorage[*dto.ExecutionRequest](monitoring.MeasurementExecutionsAWS, nil),
 		runningExecutions: make(map[execution.ID]context.CancelFunc),
 		onDestroy:         onDestroy,
 		environment:       environment,

--- a/internal/runner/execution_environment.go
+++ b/internal/runner/execution_environment.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"encoding/json"
+	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/openHPI/poseidon/pkg/dto"
+	"strconv"
 )
 
 // ExecutionEnvironment are groups of runner that share the configuration stored in the environment.
@@ -46,4 +48,15 @@ type ExecutionEnvironment interface {
 	DeleteRunner(id string)
 	// IdleRunnerCount returns the number of idle runners of the environment.
 	IdleRunnerCount() uint
+}
+
+// monitorEnvironmentData passes the configuration of the environment e into the monitoring Point p.
+func monitorEnvironmentData(p *write.Point, e ExecutionEnvironment, isDeletion bool) {
+	if !isDeletion && e != nil {
+		p.AddTag("image", e.Image())
+		p.AddTag("cpu_limit", strconv.Itoa(int(e.CPULimit())))
+		p.AddTag("memory_limit", strconv.Itoa(int(e.MemoryLimit())))
+		hasNetworkAccess, _ := e.NetworkAccess()
+		p.AddTag("network_access", strconv.FormatBool(hasNetworkAccess))
+	}
 }

--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -36,8 +36,8 @@ func (s *ManagerTestSuite) SetupTest() {
 	s.nomadRunnerManager = NewNomadRunnerManager(s.apiMock, ctx)
 
 	s.exerciseRunner = NewRunner(tests.DefaultRunnerID, s.nomadRunnerManager)
-	s.exerciseEnvironment = &ExecutionEnvironmentMock{}
-	s.setDefaultEnvironment()
+	s.exerciseEnvironment = createBasicEnvironmentMock(defaultEnvironmentID)
+	s.nomadRunnerManager.StoreEnvironment(s.exerciseEnvironment)
 }
 
 func mockRunnerQueries(apiMock *nomad.ExecutorAPIMock, returnedRunnerIds []string) {
@@ -81,18 +81,12 @@ func mockIdleRunners(environmentMock *ExecutionEnvironmentMock) {
 	})
 }
 
-func (s *ManagerTestSuite) setDefaultEnvironment() {
-	s.exerciseEnvironment.On("ID").Return(defaultEnvironmentID)
-	s.nomadRunnerManager.StoreEnvironment(s.exerciseEnvironment)
-}
-
 func (s *ManagerTestSuite) waitForRunnerRefresh() {
 	<-time.After(100 * time.Millisecond)
 }
 
 func (s *ManagerTestSuite) TestSetEnvironmentAddsNewEnvironment() {
-	anotherEnvironment := &ExecutionEnvironmentMock{}
-	anotherEnvironment.On("ID").Return(anotherEnvironmentID)
+	anotherEnvironment := createBasicEnvironmentMock(anotherEnvironmentID)
 	s.nomadRunnerManager.StoreEnvironment(anotherEnvironment)
 
 	job, ok := s.nomadRunnerManager.environments.Get(anotherEnvironmentID.ToString())

--- a/internal/runner/nomad_runner.go
+++ b/internal/runner/nomad_runner.go
@@ -11,18 +11,16 @@ import (
 	nomadApi "github.com/hashicorp/nomad/api"
 	"github.com/openHPI/poseidon/internal/nomad"
 	"github.com/openHPI/poseidon/pkg/dto"
+	"github.com/openHPI/poseidon/pkg/monitoring"
 	"github.com/openHPI/poseidon/pkg/storage"
 	"io"
 	"strings"
 	"time"
 )
 
-// ContextKey is the type for keys in a request context.
-type ContextKey string
-
 const (
 	// runnerContextKey is the key used to store runners in context.Context.
-	runnerContextKey ContextKey = "runner"
+	runnerContextKey dto.ContextKey = "runner"
 	// SIGQUIT is the character that causes a tty to send the SIGQUIT signal to the controlled process.
 	SIGQUIT = 0x1c
 	// executionTimeoutGracePeriod is the time to wait after sending a SIGQUIT signal to a timed out execution.
@@ -55,7 +53,7 @@ func NewNomadJob(id string, portMappings []nomadApi.PortMapping,
 		id:           id,
 		portMappings: portMappings,
 		api:          apiClient,
-		executions:   storage.NewLocalStorage[*dto.ExecutionRequest](),
+		executions:   storage.NewMonitoredLocalStorage[*dto.ExecutionRequest](monitoring.MeasurementExecutionsNomad, nil),
 		onDestroy:    onDestroy,
 	}
 	job.InactivityTimer = NewInactivityTimer(job, onDestroy)

--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -136,6 +136,9 @@ func (f File) ByteContent() []byte {
 	}
 }
 
+// ContextKey is the type for keys in a request context that is used for passing data to the next handler.
+type ContextKey string
+
 // WebSocketMessageType is the type for the messages from Poseidon to the client.
 type WebSocketMessageType string
 

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -8,69 +8,77 @@ import (
 	influxdb2API "github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/openHPI/poseidon/internal/config"
-	"github.com/openHPI/poseidon/internal/environment"
-	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/pkg/logging"
 	"io"
 	"net/http"
-	"reflect"
 	"strconv"
 	"time"
 )
 
-var log = logging.GetLogger("monitoring")
-
 const (
-	// influxdbContextKey is a key to reference the influxdb data point in the request context.
-	influxdbContextKey runner.ContextKey = "influxdb data point"
-	// influxdbMeasurementPrefix allows easier filtering in influxdb.
-	influxdbMeasurementPrefix = "poseidon_"
+	// influxdbContextKey is a key (runner.ContextKey) to reference the influxdb data point in the request context.
+	influxdbContextKey dto.ContextKey = "influxdb data point"
+	// measurementPrefix allows easier filtering in influxdb.
+	measurementPrefix          = "poseidon_"
+	measurementPoolSize        = measurementPrefix + "poolsize"
+	MeasurementIdleRunnerNomad = measurementPrefix + "nomad_idle_runners"
+	MeasurementExecutionsAWS   = measurementPrefix + "aws_executions"
+	MeasurementExecutionsNomad = measurementPrefix + "nomad_executions"
+	MeasurementEnvironments    = measurementPrefix + "environments"
+	MeasurementUsedRunner      = measurementPrefix + "used_runners"
 
 	// The keys for the monitored tags and fields.
 	influxKeyRunnerID                      = "runner_id"
 	influxKeyEnvironmentID                 = "environment_id"
-	influxKeyEnvironmentType               = "environment_type"
-	influxKeyEnvironmentIdleRunner         = "idle_runner"
 	influxKeyEnvironmentPrewarmingPoolSize = "prewarming_pool_size"
 	influxKeyRequestSize                   = "request_size"
 )
 
-// InfluxDB2Middleware is a middleware to send events to an influx database.
-func InfluxDB2Middleware(influxClient influxdb2API.WriteAPI, manager environment.Manager) mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			route := mux.CurrentRoute(r).GetName()
-			p := influxdb2.NewPointWithMeasurement(influxdbMeasurementPrefix + route)
-			p.AddTag("stage", config.Config.InfluxDB.Stage)
+var (
+	log          = logging.GetLogger("monitoring")
+	influxClient influxdb2API.WriteAPI
+)
 
-			start := time.Now().UTC()
-			p.SetTime(time.Now())
-
-			ctx := context.WithValue(r.Context(), influxdbContextKey, p)
-			requestWithPoint := r.WithContext(ctx)
-			lrw := logging.NewLoggingResponseWriter(w)
-			next.ServeHTTP(lrw, requestWithPoint)
-
-			p.AddField("duration", time.Now().UTC().Sub(start).Nanoseconds())
-			p.AddTag("status", strconv.Itoa(lrw.StatusCode))
-
-			environmentID, err := strconv.Atoi(getEnvironmentID(p))
-			if err == nil && manager != nil {
-				addEnvironmentData(p, manager, dto.EnvironmentID(environmentID))
-			}
-
-			if influxClient != nil {
-				influxClient.WritePoint(p)
-			}
-		})
+func InitializeInfluxDB(db *config.InfluxDB) (cancel func()) {
+	if db.URL == "" {
+		return func() {}
 	}
+
+	client := influxdb2.NewClient(db.URL, db.Token)
+	influxClient = client.WriteAPI(db.Organization, db.Bucket)
+	cancel = func() {
+		influxClient.Flush()
+		client.Close()
+	}
+	return cancel
+}
+
+// InfluxDB2Middleware is a middleware to send events to an influx database.
+func InfluxDB2Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		route := mux.CurrentRoute(r).GetName()
+		p := influxdb2.NewPointWithMeasurement(measurementPrefix + route)
+
+		start := time.Now().UTC()
+		p.SetTime(time.Now())
+
+		ctx := context.WithValue(r.Context(), influxdbContextKey, p)
+		requestWithPoint := r.WithContext(ctx)
+		lrw := logging.NewLoggingResponseWriter(w)
+		next.ServeHTTP(lrw, requestWithPoint)
+
+		p.AddField("duration", time.Now().UTC().Sub(start).Nanoseconds())
+		p.AddTag("status", strconv.Itoa(lrw.StatusCode))
+
+		WriteInfluxPoint(p)
+	})
 }
 
 // AddRunnerMonitoringData adds the data of the runner we want to monitor.
-func AddRunnerMonitoringData(request *http.Request, r runner.Runner) {
-	addRunnerID(request, r.ID())
-	addEnvironmentID(request, r.Environment())
+func AddRunnerMonitoringData(request *http.Request, runnerID string, environmentID dto.EnvironmentID) {
+	addRunnerID(request, runnerID)
+	addEnvironmentID(request, environmentID)
 }
 
 // addRunnerID adds the runner id to the influx data point for the current request.
@@ -99,6 +107,23 @@ func AddRequestSize(r *http.Request) {
 	addInfluxDBField(r, influxKeyRequestSize, len(body))
 }
 
+func ChangedPrewarmingPoolSize(id dto.EnvironmentID, count uint) {
+	p := influxdb2.NewPointWithMeasurement(measurementPoolSize)
+
+	p.AddTag(influxKeyEnvironmentID, strconv.Itoa(int(id)))
+	p.AddField(influxKeyEnvironmentPrewarmingPoolSize, count)
+
+	WriteInfluxPoint(p)
+}
+
+// WriteInfluxPoint schedules the indlux data point to be sent.
+func WriteInfluxPoint(p *write.Point) {
+	if influxClient != nil {
+		p.AddTag("stage", config.Config.InfluxDB.Stage)
+		influxClient.WritePoint(p)
+	}
+}
+
 // addInfluxDBTag adds a tag to the influxdb data point in the request.
 func addInfluxDBTag(r *http.Request, key, value string) {
 	dataPointFromRequest(r).AddTag(key, value)
@@ -116,33 +141,4 @@ func dataPointFromRequest(r *http.Request) *write.Point {
 		log.Error("All http request must contain an influxdb data point!")
 	}
 	return p
-}
-
-// getEnvironmentID tries to find the environment id in the influxdb data point.
-func getEnvironmentID(p *write.Point) string {
-	for _, tag := range p.TagList() {
-		if tag.Key == influxKeyEnvironmentID {
-			return tag.Value
-		}
-	}
-	return ""
-}
-
-// addEnvironmentData adds environment specific data to the influxdb data point.
-func addEnvironmentData(p *write.Point, manager environment.Manager, id dto.EnvironmentID) {
-	e, err := manager.Get(id, false)
-	if err == nil {
-		p.AddTag(influxKeyEnvironmentType, getType(e))
-		p.AddField(influxKeyEnvironmentIdleRunner, e.IdleRunnerCount())
-		p.AddField(influxKeyEnvironmentPrewarmingPoolSize, e.PrewarmingPoolSize())
-	}
-}
-
-// Get type returns the type of the passed execution environment.
-func getType(e runner.ExecutionEnvironment) string {
-	if t := reflect.TypeOf(e); t.Kind() == reflect.Ptr {
-		return t.Elem().Name()
-	} else {
-		return t.Name()
-	}
 }


### PR DESCRIPTION
including information about the number of requests, runner and executions and their durations.

What do you think? Is all the important information visualized? Could the structure of the dashboard be improved?

One visualization I am missing is how much time it takes Nomad to start the runners. This information can be added in the runner manager but it is not bound to a request of CodeOcean. This problem applies also for the statistics `idle_runner` and `prewarming_pool_size` - we send the same data with all incoming requests but not at the moment the change happens. That's the Prometheus way but not the Influx'... Maybe we should reconsider our decision to restrict the access to the influx client and to not provide it as singleton?!

I have no idea how to normalise the histogram.
