### PR TITLE
#155 Remove log statements

### DIFF
--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -190,7 +190,6 @@ func (rc *rawToCodeOceanWriter) Write(p []byte) (int, error) {
 	case <-rc.proxy.webSocketCtx.Done():
 		return 0, nil
 	default:
-		log.Info("Passed WriteToCodeOceanCheck")
 		err := rc.proxy.sendToClient(dto.WebSocketMessage{Type: rc.outputType, Data: string(p)})
 		return len(p), err
 	}
@@ -240,11 +239,9 @@ func newWebSocketProxy(connection webSocketConnection, proxyCtx context.Context)
 
 	closeHandler := connection.CloseHandler()
 	connection.SetCloseHandler(func(code int, text string) error {
-		log.Info("Before closing the connection via Handler")
 		cancelWsCommunication()
 		//nolint:errcheck // The default close handler always returns nil, so the error can be safely ignored.
 		_ = closeHandler(code, text)
-		log.Info("After closing the connection via Handler")
 		return nil
 	})
 	return proxy, nil
@@ -327,13 +324,11 @@ func (wp *webSocketProxy) closeNormal() {
 }
 
 func (wp *webSocketProxy) close(message []byte) {
-	log.Info("Before closing the connection manually")
 	err := wp.writeMessage(websocket.CloseMessage, message)
 	_ = wp.connection.Close()
 	if err != nil {
 		log.WithError(err).Warn("Error during websocket close")
 	}
-	log.Info("After closing the connection manually")
 }
 
 func (wp *webSocketProxy) writeMessage(messageType int, data []byte) error {


### PR DESCRIPTION
Closes #155 

In the last day there are no new Sentry events - that's unusual. Let's merge this PR and remove the log statements, when we are sure that we have solved this issue with PR #164.