### PR TITLE
CI cannot find AWS functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,6 @@ jobs:
           sudo ./nomad agent -dev -log-level=WARN -config e2e-config.hcl &
           until curl -s --fail http://localhost:4646/v1/agent/health ; do sleep 1; done
           chmod +x ./poseidon
-          echo $POSEIDON_AWS_FUNCTIONS
           ./poseidon &
           until curl -s --fail http://localhost:7200/api/v1/health ; do sleep 1; done
           make e2e-test

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 
 func initAWS() {
 	for i, function := range config.Config.AWS.Functions {
-		log.WithField("function", function).Warn("Yes, we do have functions.")
+		log.WithField("function", function[0:3]).Info("Yes, we do have AWS functions.")
 		id := dto.EnvironmentID(tests.DefaultEnvironmentIDAsInteger + i + 1)
 		path := helpers.BuildURL(api.BasePath, api.EnvironmentsPath, id.ToString())
 		request := dto.ExecutionEnvironmentRequest{Image: function}


### PR DESCRIPTION
Dependabot was too fast merging #184.

We have the GitHub secret `POSEIDON_AWS_FUNCTIONS` that includes the AWS function name. This secret is provided as environment variable to the e2e tests. The added log statement shows that the e2e tests have this value.
I cannot reproduce the error in this branch and currently see no reason for this flaky behavior.