### PR TITLE
Add Workflow for Java CI and specify encoding

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,0 +1,23 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
+      - name: Test with Maven
+        run: mvn --batch-mode --update-snapshots test
+        working-directory: deploy/aws/java11Exec

--- a/deploy/aws/java11Exec/pom.xml
+++ b/deploy/aws/java11Exec/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
When working on #133 and #186, I noticed that we do not execute tests for our Java environment in GitHub actions. This PR adds this functionality.