### PR TITLE
Fixes for the Grafana Dashboard

### DIFF
--- a/internal/runner/abstract_manager.go
+++ b/internal/runner/abstract_manager.go
@@ -30,8 +30,8 @@ func NewAbstractManager() *AbstractManager {
 }
 
 // MonitorRunnersEnvironmentID passes the id of the environment e into the monitoring Point p.
-func MonitorRunnersEnvironmentID(p *write.Point, e Runner, isDeletion bool) {
-	if !isDeletion && e != nil {
+func MonitorRunnersEnvironmentID(p *write.Point, e Runner, _ bool) {
+	if e != nil {
 		p.AddTag(monitoring.InfluxKeyEnvironmentID, e.Environment().ToString())
 	}
 }

--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -154,7 +154,7 @@ func (m *NomadRunnerManager) onAllocationAdded(alloc *nomadApi.Allocation, start
 
 func monitorAllocationStartupDuration(startup time.Duration, runnerID string, environmentID dto.EnvironmentID) {
 	p := influxdb2.NewPointWithMeasurement(monitoring.MeasurementIdleRunnerNomad)
-	p.AddField(monitoring.InfluxKeyDuration, startup)
+	p.AddField(monitoring.InfluxKeyDuration, startup.Nanoseconds())
 	p.AddTag(monitoring.InfluxKeyEnvironmentID, environmentID.ToString())
 	p.AddTag(monitoring.InfluxKeyRunnerID, runnerID)
 	monitoring.WriteInfluxPoint(p)


### PR DESCRIPTION
**Monitor environment id also for deletions.**
Fixes "Check why the idle runner count always equals the prewarming pool size"

Since only **new** runners have the environment id, the others are filtered out. The **removed** runners contain the lower counts for the idle runners, these values are currently not displayed.

**Fix startup time format**
Currently the startup duration is not efficiently usable since it is stored as string with different types (second, milliseconds,..). We want the duration to be uniform.
We may need to delete all existing startup duration records as flux does not allow differing types.