### PR TITLE
Change Influx field name for the startup duration

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -154,7 +154,7 @@ func (m *NomadRunnerManager) onAllocationAdded(alloc *nomadApi.Allocation, start
 
 func monitorAllocationStartupDuration(startup time.Duration, runnerID string, environmentID dto.EnvironmentID) {
 	p := influxdb2.NewPointWithMeasurement(monitoring.MeasurementIdleRunnerNomad)
-	p.AddField(monitoring.InfluxKeyDuration, startup.Nanoseconds())
+	p.AddField(monitoring.InfluxKeyStartupDuration, startup.Nanoseconds())
 	p.AddTag(monitoring.InfluxKeyEnvironmentID, environmentID.ToString())
 	p.AddTag(monitoring.InfluxKeyRunnerID, runnerID)
 	monitoring.WriteInfluxPoint(p)

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -34,6 +34,7 @@ const (
 	InfluxKeyRunnerID                      = "runner_id"
 	InfluxKeyEnvironmentID                 = "environment_id"
 	InfluxKeyDuration                      = "duration"
+	InfluxKeyStartupDuration               = "startup_" + InfluxKeyDuration
 	influxKeyEnvironmentPrewarmingPoolSize = "prewarming_pool_size"
 	influxKeyRequestSize                   = "request_size"
 )


### PR DESCRIPTION
due to a currently not resolvable type mismatch.


See https://github.com/openHPI/poseidon/pull/188
> > Fix startup time format
> 
> According to [the official FAQ](https://docs.influxdata.com/influxdb/v2.3/reference/faq/#can-i-change-a-fields-data-type) we cannot change the type of the field afterwards. I have tried many workarounds but they do not seem to work (with our version). We could:
> 
>     * Continue saving the duration as string and convert it on query-time via [flux](https://docs.influxdata.com/flux/v0.x/stdlib/universe/duration/#convert-a-string-to-a-duration).
> 
>     * Change the fields name. Instead of `duration`, `startup_duration` for example.
> 
>     * Copy the data with the new field type into a new bucket: `poseidon_v2`
> 
> 
> Which solution would you prefer @MrSerth ?


> I would proceed with a clean way and actually change the field (even though this results in some lost data).
> 
> While the last suggestion to copy everything to a new bucket seems to be a bit too much, I would go with the second solution (renaming the field) and potentially drop the outdated filed and data once we finished our analysis for the paper.

