### PR TITLE
Add environment id to periodical monitoring events.

### DIFF
--- a/internal/environment/nomad_environment.go
+++ b/internal/environment/nomad_environment.go
@@ -37,8 +37,10 @@ func NewNomadEnvironment(apiClient nomad.ExecutorAPI, jobHCL string) (*NomadEnvi
 		return nil, fmt.Errorf("error parsing Nomad job: %w", err)
 	}
 
-	return &NomadEnvironment{apiClient, jobHCL, job, storage.NewMonitoredLocalStorage[runner.Runner](
-		monitoring.MeasurementIdleRunnerNomad, runner.MonitorRunnersEnvironmentID, time.Minute)}, nil
+	e := &NomadEnvironment{apiClient, jobHCL, job, nil}
+	e.idleRunners = storage.NewMonitoredLocalStorage[runner.Runner](monitoring.MeasurementIdleRunnerNomad,
+		runner.MonitorEnvironmentID[runner.Runner](e.ID()), time.Minute)
+	return e, nil
 }
 
 func NewNomadEnvironmentFromRequest(

--- a/internal/environment/nomad_manager.go
+++ b/internal/environment/nomad_manager.go
@@ -151,13 +151,14 @@ func (m *NomadEnvironmentManager) Load() error {
 
 // newNomadEnvironmetFromJob creates a Nomad environment from the passed Nomad job definition.
 func newNomadEnvironmetFromJob(job *nomadApi.Job, apiClient nomad.ExecutorAPI) *NomadEnvironment {
-	return &NomadEnvironment{
+	e := &NomadEnvironment{
 		apiClient: apiClient,
 		jobHCL:    templateEnvironmentJobHCL,
 		job:       job,
-		idleRunners: storage.NewMonitoredLocalStorage[runner.Runner](
-			monitoring.MeasurementIdleRunnerNomad, runner.MonitorRunnersEnvironmentID, time.Minute),
 	}
+	e.idleRunners = storage.NewMonitoredLocalStorage[runner.Runner](monitoring.MeasurementIdleRunnerNomad,
+		runner.MonitorEnvironmentID[runner.Runner](e.ID()), time.Minute)
+	return e
 }
 
 // loadTemplateEnvironmentJobHCL loads the template environment job HCL from the given path.

--- a/internal/environment/nomad_manager_test.go
+++ b/internal/environment/nomad_manager_test.go
@@ -106,7 +106,7 @@ func TestNewNomadEnvironmentManager(t *testing.T) {
 	})
 
 	t.Run("loads template environment job from file", func(t *testing.T) {
-		templateJobHCL := "job \"test\" {}"
+		templateJobHCL := "job \"" + tests.DefaultTemplateJobID + "\" {}"
 		_, err := NewNomadEnvironment(nil, templateJobHCL)
 		require.NoError(t, err)
 		f := createTempFile(t, templateJobHCL)

--- a/internal/runner/abstract_manager.go
+++ b/internal/runner/abstract_manager.go
@@ -31,6 +31,13 @@ func NewAbstractManager() *AbstractManager {
 	}
 }
 
+// MonitorEnvironmentID adds the passed environment id to the monitoring Point p.
+func MonitorEnvironmentID[T any](id dto.EnvironmentID) storage.WriteCallback[T] {
+	return func(p *write.Point, _ T, _ storage.EventType) {
+		p.AddTag(monitoring.InfluxKeyEnvironmentID, id.ToString())
+	}
+}
+
 // MonitorRunnersEnvironmentID passes the id of the environment e into the monitoring Point p.
 func MonitorRunnersEnvironmentID(p *write.Point, e Runner, _ storage.EventType) {
 	if e != nil {


### PR DESCRIPTION
Otherwise, the new periodical events have no environment id and would not be valuable for the "idle runner" graph.