### PR TITLE
Fix missing environment id for monitoring data.

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -65,10 +65,8 @@ func FromContext(ctx context.Context) (Runner, bool) {
 
 // monitorExecutionsRunnerID passes the id of the runner executing the execution into the monitoring Point p.
 func monitorExecutionsRunnerID(env dto.EnvironmentID, runnerID string) storage.WriteCallback[*dto.ExecutionRequest] {
-	return func(p *write.Point, e *dto.ExecutionRequest, eventType storage.EventType) {
-		if eventType == storage.Creation && e != nil {
-			p.AddTag(monitoring.InfluxKeyRunnerID, runnerID)
-			p.AddTag(monitoring.InfluxKeyEnvironmentID, env.ToString())
-		}
+	return func(p *write.Point, _ *dto.ExecutionRequest, _ storage.EventType) {
+		p.AddTag(monitoring.InfluxKeyEnvironmentID, env.ToString())
+		p.AddTag(monitoring.InfluxKeyRunnerID, runnerID)
 	}
 }


### PR DESCRIPTION
Here, another condition that was preventing some monitoring events from having the environment and runner id as tag.