### PR TITLE
Fix Nomad event stream is ignoring errors

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -211,11 +211,10 @@ type nomadAPIEventHandler func(event *nomadApi.Event) (done bool, err error)
 func receiveAndHandleNomadAPIEvents(stream <-chan *nomadApi.Events, handler nomadAPIEventHandler) error {
 	// If original context is canceled, the stream will be closed by Nomad and we exit the for loop.
 	for events := range stream {
-		if events.IsHeartbeat() {
-			continue
-		}
 		if err := events.Err; err != nil {
 			return fmt.Errorf("error receiving events: %w", err)
+		} else if events.IsHeartbeat() {
+			continue
 		}
 		for _, event := range events.Events {
 			// Don't take the address of the loop variable as the underlying value might change

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -131,6 +131,18 @@ func WriteInfluxPoint(p *write.Point) {
 	if influxClient != nil {
 		p.AddTag("stage", config.Config.InfluxDB.Stage)
 		influxClient.WritePoint(p)
+	} else {
+		entry := log.WithField("name", p.Name())
+		for _, tag := range p.TagList() {
+			if tag.Key == "event_type" && tag.Value == "periodically" {
+				return
+			}
+			entry = entry.WithField(tag.Key, tag.Value)
+		}
+		for _, field := range p.FieldList() {
+			entry = entry.WithField(field.Key, field.Value)
+		}
+		entry.Debug("Influx data point")
 	}
 }
 


### PR DESCRIPTION
when an event stream could be established once.

Closes #204 

`events.IsHeartbeat()` is false positive for error events. This way we ignored the `unexpected EOF` error that we receive when Nomad restarts.