### PR TITLE
Refine default task command

### DIFF
--- a/internal/nomad/job.go
+++ b/internal/nomad/job.go
@@ -17,7 +17,7 @@ const (
 	TaskName              = "default-task"
 	TaskCount             = 1
 	TaskDriver            = "docker"
-	TaskCommand           = "sleep"
+	TaskCommand           = "sh"
 	ConfigTaskGroupName   = "config"
 	ConfigTaskName        = "config"
 	ConfigTaskDriver      = "exec"
@@ -33,7 +33,7 @@ const (
 
 var (
 	ErrorInvalidJobID = errors.New("invalid job id")
-	TaskArgs          = []string{"infinity"}
+	TaskArgs          = []string{"-c","'sleep infinity'"}
 )
 
 func (a *APIClient) RegisterRunnerJob(template *nomadApi.Job) error {


### PR DESCRIPTION
The `sleep infinity` command does not provide proper handling of child processes. If started as a subprocess of `/bin/sh`, it will prevent its parent process from terminating while the parent process itself handles subsequent child processes.

This request is loosely connected to [issue #211](https://github.com/openHPI/poseidon/issues/211). 