### PR TITLE
#211 Start Daemons and switch user per execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,21 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: poseidon
+      - name: Get current branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+      - name: Checkout matching branch for Dockerfiles (optional)
+        id: checkout-dockerfiles
+        if: steps.branch-name.outputs.is_default == 'false'
+        uses: actions/checkout@v3
+        continue-on-error: true
+        with:
+          repository: openHPI/dockerfiles
+          path: deploy/dockerfiles
+          ref: ${{ steps.branch-name.outputs.current_branch }}
+      - name: Build new e2e test image (optional)
+        if: steps.checkout-dockerfiles.outcome == 'success'
+        run: make e2e-test-docker-image
       - name: Run e2e tests
         run: |
           sudo ./nomad agent -dev -log-level=WARN -config e2e-config.hcl &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       POSEIDON_AWS_ENABLED: true
       POSEIDON_AWS_ENDPOINT: ${{ secrets.POSEIDON_AWS_ENDPOINT }}
       POSEIDON_AWS_FUNCTIONS: ${{ secrets.POSEIDON_AWS_FUNCTIONS }}
+      POSEIDON_NOMAD_DISABLEFORCEPULL: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,16 +51,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Extract metadata (tags, labels) for Docker e2e image
-        id: e2e-meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-e2e-tests
-      - name: Build and push e2e Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: deploy/e2e-test-image/Dockerfile
-          push: true
-          tags: ${{ steps.e2e-meta.outputs.tags }}
-          labels: ${{ steps.e2e-meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tests/e2e/configuration.yaml
 # IDE files
 /.idea
 *.iml
+
+# Dockerfiles repository
+deploy/dockerfiles

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ deploy/dockerfiles: ## Clone Dockerfiles repository
 	@git clone git@github.com:$(REPOSITORY_OWNER)/dockerfiles.git deploy/dockerfiles
 
 .PHONY: e2e-test-docker-image
-e2e-test-docker-image: deploy/dockerfiles ## Build Docker image that is pushed to a registry and used in e2e tests
+e2e-test-docker-image: deploy/dockerfiles ## Build Docker image that is used in e2e tests
 	@docker build -t $(E2E_TEST_DOCKER_IMAGE) deploy/dockerfiles/$(E2E_TEST_DOCKER_CONTAINER)/$(E2E_TEST_DOCKER_TAG)
 
 .PHONY: e2e-test

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -338,6 +338,10 @@ paths:
                   description: The command to be executed. The working directory for this execution is the working directory of the image of the execution environment
                   type: string
                   example: python exercise.py
+                privilegedExecution:
+                  description: Specifies if the command should be executed as an privileged user.
+                  type: boolean
+                  default: false
                 environment:
                   description: Environment variables for this execution. The keys of this object are the variable names and the value of each key is the value of the variable with the same name. The environment variables of the system remain accessible.
                   type: object

--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -42,6 +42,8 @@ nomad:
     keyfile: ./poseidon.key
   # Nomad namespace to use. If unset, 'default' is used
   namespace: poseidon
+  # Prefer local Docker images over pulling them from a registry. Images with the `latest` tag will always be force pulled by Nomad regardless of this configuration.
+  disableforcepull: true
 
 aws:
   # Specifies whether AWS should be used as executor.

--- a/deploy/e2e-test-image/Dockerfile
+++ b/deploy/e2e-test-image/Dockerfile
@@ -1,9 +1,0 @@
-# Minimal working Docker image used in our e2e tests
-FROM python:latest
-
-RUN useradd --home-dir /workspace --no-create-home --user-group user && \
-    mkdir /workspace && chown user:user /workspace
-
-WORKDIR /workspace
-
-USER user

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,3 +84,14 @@ If the path is not set up correctly or with a different name, the placement of a
 ### Use gVisor as a sandbox
 
 We recommend using gVisor as a sandbox for the execution environments. First, [install gVisor following the official documentation](https://gvisor.dev/docs/user_guide/install/) and second, adapt the `/etc/docker/daemon.json` with reasonable defaults as shown in our [example configuration for Docker](./resources/docker.daemon.json).
+
+## Supported Docker Images
+
+In general, any Docker image can be used as an execution environment. 
+
+### Users
+
+If the `privilegedExecution` flag is set to `true` during execution, no additional user is required. Otherwise, the following two requirements must be met:
+
+- A non-privileged user called `user` needs to be present in the image. This user is used to execute the code.
+- The Docker image needs to have a `/sbin/setuser` script allowing the execution of the user code as a non-root user, similar to `/usr/bin/su`.

--- a/internal/api/websocket_test.go
+++ b/internal/api/websocket_test.go
@@ -100,7 +100,8 @@ func (s *WebSocketTestSuite) TestWebsocketConnection() {
 	s.Run("Executes the request in the runner", func() {
 		<-time.After(tests.ShortTimeout)
 		s.apiMock.AssertCalled(s.T(), "ExecuteCommand",
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("bool"),
+			mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	s.Run("Can send input", func() {
@@ -405,6 +406,7 @@ var executionRequestSleep = dto.ExecutionRequest{Command: "sleep infinity"}
 // until the execution receives a SIGQUIT.
 func mockAPIExecuteSleep(api *nomad.ExecutorAPIMock) <-chan bool {
 	canceled := make(chan bool, 1)
+
 	mockAPIExecute(api, &executionRequestSleep,
 		func(_ string, ctx context.Context, _ []string, _ bool,
 			stdin io.Reader, stdout io.Writer, stderr io.Writer,
@@ -446,12 +448,12 @@ func mockAPIExecuteExitNonZero(api *nomad.ExecutorAPIMock) {
 // corresponding to the given ExecutionRequest is called.
 func mockAPIExecute(api *nomad.ExecutorAPIMock, request *dto.ExecutionRequest,
 	run func(runnerId string, ctx context.Context, command []string, tty bool,
-		stdin io.Reader, stdout, stderr io.Writer) (int, error),
-) {
+		stdin io.Reader, stdout, stderr io.Writer) (int, error)) {
 	call := api.On("ExecuteCommand",
 		mock.AnythingOfType("string"),
 		mock.Anything,
 		request.FullCommand(),
+		mock.AnythingOfType("bool"),
 		mock.AnythingOfType("bool"),
 		mock.Anything,
 		mock.Anything,
@@ -461,9 +463,9 @@ func mockAPIExecute(api *nomad.ExecutorAPIMock, request *dto.ExecutionRequest,
 			args.Get(1).(context.Context),
 			args.Get(2).([]string),
 			args.Get(3).(bool),
-			args.Get(4).(io.Reader),
-			args.Get(5).(io.Writer),
-			args.Get(6).(io.Writer))
+			args.Get(5).(io.Reader),
+			args.Get(6).(io.Writer),
+			args.Get(7).(io.Writer))
 		call.ReturnArguments = mock.Arguments{exit, err}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,8 @@ var (
 				CertFile: "",
 				KeyFile:  "",
 			},
-			Namespace: "default",
+			Namespace:        "default",
+			DisableForcePull: false,
 		},
 		AWS: AWS{
 			Enabled:   false,
@@ -88,12 +89,13 @@ func (s *server) URL() *url.URL {
 
 // Nomad configures the used Nomad cluster.
 type Nomad struct {
-	Enabled   bool
-	Address   string
-	Port      int
-	Token     string
-	TLS       TLS
-	Namespace string
+	Enabled          bool
+	Address          string
+	Port             int
+	Token            string
+	TLS              TLS
+	Namespace        string
+	DisableForcePull bool
 }
 
 // URL returns the URL for the configured Nomad cluster.

--- a/internal/nomad/executor_api_mock.go
+++ b/internal/nomad/executor_api_mock.go
@@ -78,20 +78,20 @@ func (_m *ExecutorAPIMock) Execute(jobID string, ctx context.Context, command []
 	return r0, r1
 }
 
-// ExecuteCommand provides a mock function with given fields: allocationID, ctx, command, tty, stdin, stdout, stderr
-func (_m *ExecutorAPIMock) ExecuteCommand(allocationID string, ctx context.Context, command []string, tty bool, stdin io.Reader, stdout io.Writer, stderr io.Writer) (int, error) {
-	ret := _m.Called(allocationID, ctx, command, tty, stdin, stdout, stderr)
+// ExecuteCommand provides a mock function with given fields: allocationID, ctx, command, tty, privilegedExecution, stdin, stdout, stderr
+func (_m *ExecutorAPIMock) ExecuteCommand(allocationID string, ctx context.Context, command []string, tty bool, privilegedExecution bool, stdin io.Reader, stdout io.Writer, stderr io.Writer) (int, error) {
+	ret := _m.Called(allocationID, ctx, command, tty, privilegedExecution, stdin, stdout, stderr)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(string, context.Context, []string, bool, io.Reader, io.Writer, io.Writer) int); ok {
-		r0 = rf(allocationID, ctx, command, tty, stdin, stdout, stderr)
+	if rf, ok := ret.Get(0).(func(string, context.Context, []string, bool, bool, io.Reader, io.Writer, io.Writer) int); ok {
+		r0 = rf(allocationID, ctx, command, tty, privilegedExecution, stdin, stdout, stderr)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, context.Context, []string, bool, io.Reader, io.Writer, io.Writer) error); ok {
-		r1 = rf(allocationID, ctx, command, tty, stdin, stdout, stderr)
+	if rf, ok := ret.Get(1).(func(string, context.Context, []string, bool, bool, io.Reader, io.Writer, io.Writer) error); ok {
+		r1 = rf(allocationID, ctx, command, tty, privilegedExecution, stdin, stdout, stderr)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/nomad/job.go
+++ b/internal/nomad/job.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	nomadApi "github.com/hashicorp/nomad/api"
+	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"strconv"
 	"strings"
@@ -146,7 +147,11 @@ func FindAndValidateDefaultTask(taskGroup *nomadApi.TaskGroup) *nomadApi.Task {
 func SetForcePullFlag(job *nomadApi.Job, value bool) {
 	taskGroup := FindAndValidateDefaultTaskGroup(job)
 	task := FindAndValidateDefaultTask(taskGroup)
-	task.Config["force_pull"] = value
+	if config.Config.Nomad.DisableForcePull {
+		task.Config["force_pull"] = false
+	} else {
+		task.Config["force_pull"] = value
+	}
 }
 
 // IsEnvironmentTemplateID checks if the passed job id belongs to a template job.

--- a/internal/nomad/job_test.go
+++ b/internal/nomad/job_test.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	nomadApi "github.com/hashicorp/nomad/api"
+	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/tests/helpers"
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,27 @@ func TestFindOrCreateTask(t *testing.T) {
 		assert.NotNil(t, task)
 		assert.Equal(t, 1, len(group.Tasks))
 		assert.Equal(t, expectedTask, task)
+	})
+}
+
+func TestSetForcePullFlag(t *testing.T) {
+	_, job := helpers.CreateTemplateJob()
+	taskGroup := FindAndValidateDefaultTaskGroup(job)
+	task := FindAndValidateDefaultTask(taskGroup)
+
+	t.Run("Ignoring passed value if DisableForcePull", func(t *testing.T) {
+		config.Config.Nomad.DisableForcePull = true
+		SetForcePullFlag(job, true)
+		assert.Equal(t, false, task.Config["force_pull"])
+	})
+
+	t.Run("Using passed value if not DisableForcePull", func(t *testing.T) {
+		config.Config.Nomad.DisableForcePull = false
+		SetForcePullFlag(job, true)
+		assert.Equal(t, true, task.Config["force_pull"])
+
+		SetForcePullFlag(job, false)
+		assert.Equal(t, false, task.Config["force_pull"])
 	})
 }
 

--- a/internal/runner/aws_runner.go
+++ b/internal/runner/aws_runner.go
@@ -90,6 +90,7 @@ func (w *AWSFunctionWorkload) ExecuteInteractively(id string, _ io.ReadWriter, s
 		return nil, nil, ErrorUnknownExecution
 	}
 	hideEnvironmentVariables(request, "AWS")
+	request.PrivilegedExecution = true // AWS does not support multiple users at this moment.
 	command, ctx, cancel := prepareExecution(request)
 	exitInternal := make(chan ExitInfo)
 	exit := make(chan ExitInfo, 1)

--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -17,11 +17,14 @@ type RunnerRequest struct {
 
 // ExecutionRequest is the expected json structure of the request body for the ExecuteCommand function.
 type ExecutionRequest struct {
-	Command     string
-	TimeLimit   int
-	Environment map[string]string
+	Command             string
+	PrivilegedExecution bool
+	TimeLimit           int
+	Environment         map[string]string
 }
 
+// FullCommand joins the environment variables and the passed command into an "sh -c" wrapped command.
+// It does not handle the TimeLimit or the PrivilegedExecution flag.
 func (er *ExecutionRequest) FullCommand() []string {
 	command := make([]string, 0)
 	command = append(command, "env")

--- a/tests/e2e/runners_test.go
+++ b/tests/e2e/runners_test.go
@@ -224,7 +224,7 @@ func (s *E2ETestSuite) TestCopyFilesRoute_PermissionDenied() {
 		newFileContent := []byte("New content")
 		copyFilesRequestByteString, err := json.Marshal(&dto.UpdateFileSystemRequest{
 			Copy: []dto.File{
-				{Path: "/dev/sda", Content: []byte(tests.DefaultFileContent)},
+				{Path: "/proc/1/environ", Content: []byte(tests.DefaultFileContent)},
 				{Path: tests.DefaultFileName, Content: newFileContent},
 			},
 		})
@@ -237,7 +237,7 @@ func (s *E2ETestSuite) TestCopyFilesRoute_PermissionDenied() {
 		internalServerError := new(dto.InternalServerError)
 		err = json.NewDecoder(resp.Body).Decode(internalServerError)
 		s.NoError(err)
-		s.Contains(internalServerError.Message, "Cannot open: Permission denied")
+		s.Contains(internalServerError.Message, "Cannot open: ")
 		_ = resp.Body.Close()
 
 		s.Run("File content can be printed on runner", func() {
@@ -257,7 +257,7 @@ func (s *E2ETestSuite) TestCopyFilesRoute_PermissionDenied() {
 				newFileContent := []byte("New content")
 				copyFilesRequestByteString, err := json.Marshal(&dto.UpdateFileSystemRequest{
 					Copy: []dto.File{
-						{Path: "/dev/sda", Content: []byte(tests.DefaultFileContent)},
+						{Path: "/proc/1/environ", Content: []byte(tests.DefaultFileContent)},
 						{Path: tests.DefaultFileName, Content: newFileContent},
 					},
 				})
@@ -271,7 +271,7 @@ func (s *E2ETestSuite) TestCopyFilesRoute_PermissionDenied() {
 
 				stdout, stderr := s.PrintContentOfFileOnRunner(runnerID, tests.DefaultFileName)
 				s.Equal(string(newFileContent), stdout)
-				s.Contains(stderr, "Permission denied")
+				s.Contains(stderr, "Exception")
 			})
 		}
 	})

--- a/tests/e2e/websocket_test.go
+++ b/tests/e2e/websocket_test.go
@@ -82,6 +82,19 @@ func (s *E2ETestSuite) TestOutputToStderr() {
 	}
 }
 
+func (s *E2ETestSuite) TestUserNomad() {
+	s.Run("unprivileged", func() {
+		stdout, _, _ := ExecuteNonInteractive(&s.Suite, tests.DefaultEnvironmentIDAsInteger,
+			&dto.ExecutionRequest{Command: "id --name --user", PrivilegedExecution: false}, nil)
+		s.Require().NotEqual("root", stdout)
+	})
+	s.Run("privileged", func() {
+		stdout, _, _ := ExecuteNonInteractive(&s.Suite, tests.DefaultEnvironmentIDAsInteger,
+			&dto.ExecutionRequest{Command: "id --name --user", PrivilegedExecution: true}, nil)
+		s.Require().Equal("root\r\n", stdout)
+	})
+}
+
 // AWS environments do not support stdin at this moment therefore they cannot take this test.
 func (s *E2ETestSuite) TestCommandHead() {
 	hello := "Hello World!"


### PR DESCRIPTION
_Part of #211 and https://github.com/openHPI/dockerfiles/pull/23, Closes #211 and closes #213, //cc @koelibri_

This PR:
- allows using a local Docker image for Development and Testing
- builds the e2e test image if modified in the current branch
- Switches the user per code execution. Unfortunately, this only works in Nomad so far (as AWS does not yet have custom images) and also imposes the first requirement on Docker images (the availability of the `/sbin/setuser` command). I would be glad to prevent the dependency on the Docker images (and the `/sbin/setuser` command) but didn't find a suitable workaround. Should we add some configuration option for this behaviour?

Open ToDos:
- Find a generalizable solution for `/sbin/setuser` dependency.
- Add AWS support.
- Refactor code to be cleaner.

Assistance for the open points is very appreciated!