### PR TITLE
Config cleanup

### DIFF
--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -16,9 +16,9 @@ server:
     # The path to the key file used for TLS
     keyfile: ./poseidon.key
   # If true, an additional WebSocket connection will be opened to split stdout and stderr when executing interactively
-  interactiveStderr: true
+  interactivestderr: true
   # If set, the file at the given path overwrites the default Nomad job file in internal/environment/template-environment-job.hcl
-  templateJobFile: ./poseidon.hcl
+  templatejobfile: ./poseidon.hcl
 
 # Configuration of the used Nomad cluster
 nomad:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,14 +6,14 @@ Poseidon can be configured to suit different use cases.
 ## Poseidon
 
 The file `config/config.go` contains a configuration struct containing all possible configuration options for Poseidon. The file also defines default values for most of the configuration options.  
-The options *can* be overridden with a yaml configuration file whose path can be configured with the flag `-config`. By default, Poseidon searches for `configuration.yaml` in the working directory. `configuration.example.yaml` is an example for a configuration file and contains explanations for all options.
+The options *can* be overridden with a yaml configuration file whose path can be configured with the flag `-config`. By default, Poseidon searches for `configuration.yaml` in the working directory. `configuration.example.yaml` is an example for a configuration file and contains explanations for all options. The keys of the options specified in the configuration file must be written in lowercase.  
 The options *can* also be overridden by environment variables. Currently, only the Go types `string`, `int`, `bool` and `struct` (nested) are implemented. The name of the environment variable is constructed as follows: `POSEIDON_(<name of nested struct>_)*<name of field>` (all letters are uppercase).
 
 The precedence of configuration possibilities is:
 
 1. Environment variables
-1. Configuration file
-1. Default values
+2. Configuration file
+3. Default values
 
 If a value is not specified, the value of the subsequent possibility is used.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,9 +65,8 @@ var (
 	configurationInitialized = false
 	log                      = logging.GetLogger("config")
 	TLSConfig                = &tls.Config{
-		MinVersion:               tls.VersionTLS13,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 	}
 	ErrConfigInitialized = errors.New("configuration is already initialized")
 )


### PR DESCRIPTION
While working on #215, I noticed that some of our config options are not correctly processed. 
- Those YML keys containing uppercase letters won't be recognised. Therefore, I changed all occurrences to lowercase letters and added some documentation.
- The `PreferServerCipherSuites` option is deprecated and ignored, as outlined in the [documentation](https://pkg.go.dev/crypto/tls#Config.PreferServerCipherSuites). I removed the config option.