### PR TITLE
Catch context canceled error

### DIFF
--- a/internal/api/runners.go
+++ b/internal/api/runners.go
@@ -133,6 +133,7 @@ func (r *RunnerController) updateFileSystem(writer http.ResponseWriter, request 
 
 func (r *RunnerController) fileContent(writer http.ResponseWriter, request *http.Request) {
 	targetRunner, _ := runner.FromContext(request.Context())
+	monitoring.AddRunnerMonitoringData(request, targetRunner.ID(), targetRunner.Environment())
 	path := request.URL.Query().Get(PathKey)
 	privilegedExecution, err := strconv.ParseBool(request.URL.Query().Get(PrivilegedExecutionKey))
 	if err != nil {


### PR DESCRIPTION
Related to https://github.com/openHPI/codeocean/pull/1389#discussion_r988942608

I would propose to additionally extend the `ContentLengthWriter` (a small bit) to monitor the expected content length and actual length?!