### PR TITLE
Support protected directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ LOWER_REPOSITORY_OWNER = $(shell echo $(REPOSITORY_OWNER) | tr A-Z a-z)
 E2E_TEST_DOCKER_CONTAINER := co_execenv_java
 E2E_TEST_DOCKER_TAG := 17
 E2E_TEST_DOCKER_IMAGE = "$(LOWER_REPOSITORY_OWNER)/$(E2E_TEST_DOCKER_CONTAINER):$(E2E_TEST_DOCKER_TAG)"
+# The base image of the e2e test image. This is used to build the base image as well.
+E2E_TEST_BASE_CONTAINER := docker_exec_phusion
+E2E_TEST_BASE_IMAGE = "$(LOWER_REPOSITORY_OWNER)/$(E2E_TEST_BASE_CONTAINER)"
 
 default: help
 
@@ -98,6 +101,7 @@ deploy/dockerfiles: ## Clone Dockerfiles repository
 
 .PHONY: e2e-test-docker-image
 e2e-test-docker-image: deploy/dockerfiles ## Build Docker image that is used in e2e tests
+	@docker build -t $(E2E_TEST_BASE_IMAGE) -f deploy/dockerfiles/$(E2E_TEST_BASE_CONTAINER)
 	@docker build -t $(E2E_TEST_DOCKER_IMAGE) deploy/dockerfiles/$(E2E_TEST_DOCKER_CONTAINER)/$(E2E_TEST_DOCKER_TAG)
 
 .PHONY: e2e-test

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -404,7 +404,7 @@ paths:
                     type: object
                     properties:
                       path:
-                        description: Location where the file should be placed. Can be absolute (starting with /) or relative to the workspace directory. Missing parent directories are created. If this ends with a /, the path is interpreted as a directory and content is ignored
+                        description: Location where the file should be placed. Can be absolute (starting with /) or relative to the workspace directory. Missing parent directories are created. If this ends with a /, the path is interpreted as a directory and content is ignored. Currently, every file/directory is owned by root but the directories have the sticky bit set to allow unprivileged file creation.
                         type: string
                         example: /etc/passwd
                       content:

--- a/internal/runner/nomad_runner.go
+++ b/internal/runner/nomad_runner.go
@@ -342,7 +342,7 @@ func tarHeader(file dto.File) *tar.Header {
 		return &tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     file.CleanedPath(),
-			Mode:     0o755,
+			Mode:     0o1777, // See #236. Sticky bit is to allow creating files next to write-protected files.
 		}
 	} else {
 		return &tar.Header{


### PR DESCRIPTION
by setting the sticky bit to all explicitly requested directories.

Closes #236 

This MR requires explicit requests for (protected) directories in the update file system route.