### PR TITLE
Rebuild base image for e2e images as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ LOWER_REPOSITORY_OWNER = $(shell echo $(REPOSITORY_OWNER) | tr A-Z a-z)
 E2E_TEST_DOCKER_CONTAINER := co_execenv_java
 E2E_TEST_DOCKER_TAG := 17
 E2E_TEST_DOCKER_IMAGE = "$(LOWER_REPOSITORY_OWNER)/$(E2E_TEST_DOCKER_CONTAINER):$(E2E_TEST_DOCKER_TAG)"
+# The base image of the e2e test image. This is used to build the base image as well.
+E2E_TEST_BASE_CONTAINER := docker_exec_phusion
+E2E_TEST_BASE_IMAGE = "$(LOWER_REPOSITORY_OWNER)/$(E2E_TEST_BASE_CONTAINER)"
 
 default: help
 
@@ -98,6 +101,7 @@ deploy/dockerfiles: ## Clone Dockerfiles repository
 
 .PHONY: e2e-test-docker-image
 e2e-test-docker-image: deploy/dockerfiles ## Build Docker image that is used in e2e tests
+	@docker build -t $(E2E_TEST_BASE_IMAGE) -f deploy/dockerfiles/$(E2E_TEST_BASE_CONTAINER)
 	@docker build -t $(E2E_TEST_DOCKER_IMAGE) deploy/dockerfiles/$(E2E_TEST_DOCKER_CONTAINER)/$(E2E_TEST_DOCKER_TAG)
 
 .PHONY: e2e-test


### PR DESCRIPTION
Unfortunately, with the current e2e pipeline, we are just building the final Docker image which is based on the `openhpi/docker_exec_phusion` image. In order to test with changes in the base image, we need to build that as well.

This branch tests with the latest version of the [dockerfiles](https://github.com/openHPI/dockerfiles) repository (hence the branch name) and will be merged into #240.