### PR TITLE
Change Grafana panel label structure

### DIFF
--- a/deploy/grafana-dashboard/queries/execution-duration-hist.flux
+++ b/deploy/grafana-dashboard/queries/execution-duration-hist.flux
@@ -19,7 +19,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/execution-duration.flux
+++ b/deploy/grafana-dashboard/queries/execution-duration.flux
@@ -20,7 +20,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image"])

--- a/deploy/grafana-dashboard/queries/executions-per-minute-time.flux
+++ b/deploy/grafana-dashboard/queries/executions-per-minute-time.flux
@@ -19,7 +19,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/executions-per-minute.flux
+++ b/deploy/grafana-dashboard/queries/executions-per-minute.flux
@@ -20,7 +20,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: data, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image"])

--- a/deploy/grafana-dashboard/queries/executions-per-runner-hist.flux
+++ b/deploy/grafana-dashboard/queries/executions-per-runner-hist.flux
@@ -29,7 +29,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/executions-per-runner.flux
+++ b/deploy/grafana-dashboard/queries/executions-per-runner.flux
@@ -29,7 +29,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image"])

--- a/deploy/grafana-dashboard/queries/idle-runner.flux
+++ b/deploy/grafana-dashboard/queries/idle-runner.flux
@@ -17,7 +17,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/number-of-executions.flux
+++ b/deploy/grafana-dashboard/queries/number-of-executions.flux
@@ -18,7 +18,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image"])

--- a/deploy/grafana-dashboard/queries/prewarming-pool-size.flux
+++ b/deploy/grafana-dashboard/queries/prewarming-pool-size.flux
@@ -17,7 +17,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/request-body-size.flux
+++ b/deploy/grafana-dashboard/queries/request-body-size.flux
@@ -17,7 +17,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/runner-per-minute.flux
+++ b/deploy/grafana-dashboard/queries/runner-per-minute.flux
@@ -21,7 +21,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])

--- a/deploy/grafana-dashboard/queries/runner-startup-duration.flux
+++ b/deploy/grafana-dashboard/queries/runner-startup-duration.flux
@@ -17,7 +17,7 @@ envMapping = from(bucket: "poseidon/autogen")
   |> last()
   |> keep(columns: ["id", "image", "stage"])
   |> rename(columns: {id: "environment_id"})
-  |> map(fn: (r) => ({ r with image: strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_") + "(" + strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + ")" }))
+  |> map(fn: (r) => ({ r with image: strings.substring(v: r.stage, start: 0, end: 1) + r.environment_id + "/" + strings.trimPrefix(v: r.image, prefix: "openhpi/co_execenv_")}))
 
 join(tables: {key1: result, key2: envMapping}, on: ["environment_id", "stage"], method: "inner")
   |> keep(columns: ["_value", "image", "_time"])


### PR DESCRIPTION
by moving the stage and environment id to the front.

For the environment specific panels, the information about the stage, the environment id and the human readable image is important. I could not find another way to display those information apart concatenating them. I thought about setting the [display name](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-standard-options/) to a specific column and assumed other labels/columns would be displayed by hovering, but I could not confirm that.

To do a small readability improvement, I moved the stage and environment id information to the front.

Related to #244 

