### PR TITLE
Fix wrongly filtered data

### DIFF
--- a/deploy/grafana-dashboard/queries/request-latency.flux
+++ b/deploy/grafana-dashboard/queries/request-latency.flux
@@ -1,7 +1,7 @@
 from(bucket: "poseidon/autogen")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r["_field"] == "duration")
-  |> filter(fn: (r) => contains(value: r["environment_id"], set: ${environment_ids:json}))
+  |> filter(fn: (r) => (not exists r.environment_id) or contains(value: r["environment_id"], set: ${environment_ids:json}))
   |> filter(fn: (r) => (not exists r.stage) or contains(value: r["stage"], set: ${stages:json}))
   |> keep(columns: ["_time", "_value"])
   |> aggregateWindow(every: v.windowPeriod, fn: mean)

--- a/deploy/grafana-dashboard/queries/requests-per-minute.flux
+++ b/deploy/grafana-dashboard/queries/requests-per-minute.flux
@@ -3,7 +3,7 @@ import "date"
 data = from(bucket: "poseidon/autogen")
   |> range(start: date.truncate(t: v.timeRangeStart, unit: 1m), stop: date.truncate(t: v.timeRangeStop, unit: 1m))
   |> filter(fn: (r) => r._field == "duration")
-  |> filter(fn: (r) => contains(value: r["environment_id"], set: ${environment_ids:json}))
+  |> filter(fn: (r) => (not exists r.environment_id) or contains(value: r["environment_id"], set: ${environment_ids:json}))
   |> filter(fn: (r) => (not exists r.stage) or contains(value: r["stage"], set: ${stages:json}))
   |> keep(columns: ["_time", "_value", "status"])
 

--- a/deploy/grafana-dashboard/queries/service-time.flux
+++ b/deploy/grafana-dashboard/queries/service-time.flux
@@ -1,7 +1,7 @@
 from(bucket: "poseidon/autogen")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r["_field"] == "duration")
-  |> filter(fn: (r) => contains(value: r["environment_id"], set: ${environment_ids:json}))
+  |> filter(fn: (r) => (not exists r.environment_id) or contains(value: r["environment_id"], set: ${environment_ids:json}))
   |> filter(fn: (r) => (not exists r.stage) or contains(value: r["stage"], set: ${stages:json}))
   |> keep(columns: ["_time", "_value", "_measurement"])
   |> aggregateWindow(every: duration(v: int(v: v.windowPeriod) * 10), fn: (tables=<-, column) => tables |> quantile(q: 0.999))


### PR DESCRIPTION
by not assuming that every duration data point has a environment id tag.

Related to #244 