### PR TITLE
Fix/#249 1 q list file system

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -70,6 +70,7 @@ func (m *NomadRunnerManager) markRunnerAsUsed(runner Runner, timeoutDuration int
 }
 
 func (m *NomadRunnerManager) Return(r Runner) error {
+	m.usedRunners.Delete(r.ID())
 	r.StopTimeout()
 	err := util.RetryExponential(time.Second, func() (err error) {
 		if err = m.apiClient.DeleteJob(r.ID()); err != nil {
@@ -80,7 +81,6 @@ func (m *NomadRunnerManager) Return(r Runner) error {
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
-	m.usedRunners.Delete(r.ID())
 	return nil
 }
 


### PR DESCRIPTION
See #249

This may be a race condition between the runner removal and the `listFileSystem` route. To reduce the time span of this condition we first remove the runner from the internal `usedRunner` representation as then the `listFileSystem` is more likely to return `RunnerNotFound`.
If this error appears again, we got more debug information (the runner id) to take a closer look.