### PR TITLE
Fix panic on influx shutdown

### DIFF
--- a/cmd/poseidon/main.go
+++ b/cmd/poseidon/main.go
@@ -215,11 +215,11 @@ func main() {
 	initSentry(&config.Config.Sentry, config.Config.Profiling.Enabled)
 	defer shutdownSentry()
 
-	stopProfiling := initProfiling(config.Config.Profiling)
-	defer stopProfiling()
-
 	cancel := monitoring.InitializeInfluxDB(&config.Config.InfluxDB)
 	defer cancel()
+
+	stopProfiling := initProfiling(config.Config.Profiling)
+	defer stopProfiling()
 
 	server := initServer()
 	go runServer(server)

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -82,6 +82,7 @@ func InitializeInfluxDB(db *config.InfluxDB) (cancel func()) {
 	// Flush the influx client on shutdown.
 	cancel = func() {
 		influxClient.Flush()
+		influxClient = nil
 		client.Close()
 	}
 	return cancel
@@ -149,7 +150,7 @@ func ChangedPrewarmingPoolSize(id dto.EnvironmentID, count uint) {
 	WriteInfluxPoint(p)
 }
 
-// WriteInfluxPoint schedules the indlux data point to be sent.
+// WriteInfluxPoint schedules the influx data point to be sent.
 func WriteInfluxPoint(p *write.Point) {
 	if influxClient != nil {
 		p.AddTag("stage", config.Config.InfluxDB.Stage)


### PR DESCRIPTION
Closes #303 

Influx was shutdown before Poseidon was terminated. In that mean time the Profiling data is written. Also in that mean time, a periodical influx event can trigger a panic since influx is already shutdown.

We implemented two changes, each fixing this scenario.