### PR TITLE
Fix multiple user Runner use

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -147,7 +147,7 @@ func (m *NomadRunnerManager) onAllocationAdded(alloc *nomadApi.Allocation, start
 	}
 
 	if _, ok := m.usedRunners.Get(alloc.JobID); ok {
-		log.WithField("id", alloc.JobID).Debug("Started Runner is already in use")
+		log.WithField("id", alloc.JobID).WithField("states", alloc.TaskStates).Error("Started Runner is already in use")
 		return
 	}
 

--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -146,6 +146,11 @@ func (m *NomadRunnerManager) onAllocationAdded(alloc *nomadApi.Allocation, start
 		return
 	}
 
+	if _, ok := m.usedRunners.Get(alloc.JobID); ok {
+		log.WithField("id", alloc.JobID).Debug("Started Runner is already in use")
+		return
+	}
+
 	environmentID, err := nomad.EnvironmentIDFromRunnerID(alloc.JobID)
 	if err != nil {
 		log.WithError(err).Warn("Allocation could not be added")

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -21,14 +21,15 @@ const (
 	// influxdbContextKey is a key (runner.ContextKey) to reference the influxdb data point in the request context.
 	influxdbContextKey dto.ContextKey = "influxdb data point"
 	// measurementPrefix allows easier filtering in influxdb.
-	measurementPrefix          = "poseidon_"
-	measurementPoolSize        = measurementPrefix + "poolsize"
-	MeasurementIdleRunnerNomad = measurementPrefix + "nomad_idle_runners"
-	MeasurementExecutionsAWS   = measurementPrefix + "aws_executions"
-	MeasurementExecutionsNomad = measurementPrefix + "nomad_executions"
-	MeasurementEnvironments    = measurementPrefix + "environments"
-	MeasurementUsedRunner      = measurementPrefix + "used_runners"
-	MeasurementFileDownload    = measurementPrefix + "file_download"
+	measurementPrefix           = "poseidon_"
+	measurementPoolSize         = measurementPrefix + "poolsize"
+	MeasurementNomadAllocations = measurementPrefix + "nomad_allocations"
+	MeasurementIdleRunnerNomad  = measurementPrefix + "nomad_idle_runners"
+	MeasurementExecutionsAWS    = measurementPrefix + "aws_executions"
+	MeasurementExecutionsNomad  = measurementPrefix + "nomad_executions"
+	MeasurementEnvironments     = measurementPrefix + "environments"
+	MeasurementUsedRunner       = measurementPrefix + "used_runners"
+	MeasurementFileDownload     = measurementPrefix + "file_download"
 
 	// The keys for the monitored tags and fields.
 

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -166,7 +166,7 @@ func WriteInfluxPoint(p *write.Point) {
 		for _, field := range p.FieldList() {
 			entry = entry.WithField(field.Key, field.Value)
 		}
-		entry.Debug("Influx data point")
+		entry.Trace("Influx data point")
 	}
 }
 


### PR DESCRIPTION
Related to #269

When deploying (Poseidon/) Nomad, we can [observe in the logs](https://github.com/openHPI/poseidon/files/10978226/syslog.suspect.poseidon.txt) that first some Nomad-specific failures occur and after that all runner get added again.

When adding the runner (again), there was no check if the runner is already in use. Therefore, the already used runner is re-added to the idleRunner. If this (/those) runner is not reassigned to another user before the runner is destroyed (e.g. due to its timeout) there is no problem. But, if the runner (A) gets re-provided to another user, another runner (B) gets started, but in the end the runner (A) will be removed just once. When trying to remove the runner (A) the second time only an error (`DeleteJob failed: job not found`) is created. In total we have now (one) more runner and our isolation constraint failed.

For this moment it stays unexplained, why Nomad is re-adding the runner because on a normal systemd restart, Poseidon throws the error `Stopped updating the runners! Retry 1" error="error receiving events: unexpected EOF` and does not re-add all the runner. I assume the difference is that in the deployment the nomad-server stays active and just the nomad-agents (or even just their docker service) are reloading.

I've added a ~~Sentry~~ Grafana Alert to ensure that we will know when this issue happens again.