### PR TITLE
Add context to Sentry Hook

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -42,7 +42,7 @@ func NewRouter(runnerManager runner.Manager, environmentManager environment.Mana
 func configureV1Router(router *mux.Router,
 	runnerManager runner.Manager, environmentManager environment.ManagerHandler) {
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.WithField("request", r).Debug("Not Found Handler")
+		log.WithContext(r.Context()).WithField("request", r).Debug("Not Found Handler")
 		w.WriteHeader(http.StatusNotFound)
 	})
 	v1 := router.PathPrefix(BasePath).Subrouter()
@@ -75,10 +75,10 @@ func configureV1Router(router *mux.Router,
 
 // Version handles the version route.
 // It responds the release information stored in the configuration.
-func Version(writer http.ResponseWriter, _ *http.Request) {
+func Version(writer http.ResponseWriter, request *http.Request) {
 	release := config.Config.Sentry.Release
 	if len(release) > 0 {
-		sendJSON(writer, release, http.StatusOK)
+		sendJSON(writer, release, http.StatusOK, request.Context())
 	} else {
 		writer.WriteHeader(http.StatusNotFound)
 	}
@@ -87,12 +87,12 @@ func Version(writer http.ResponseWriter, _ *http.Request) {
 // StatisticsExecutionEnvironments handles the route for statistics about execution environments.
 // It responds the prewarming pool size and the number of idle runners and used runners.
 func StatisticsExecutionEnvironments(manager environment.Manager) http.HandlerFunc {
-	return func(writer http.ResponseWriter, _ *http.Request) {
+	return func(writer http.ResponseWriter, request *http.Request) {
 		result := make(map[string]*dto.StatisticalExecutionEnvironmentData)
 		environmentsData := manager.Statistics()
 		for id, data := range environmentsData {
 			result[id.ToString()] = data
 		}
-		sendJSON(writer, result, http.StatusOK)
+		sendJSON(writer, result, http.StatusOK, request.Context())
 	}
 }

--- a/internal/api/auth/auth.go
+++ b/internal/api/auth/auth.go
@@ -27,7 +27,8 @@ func HTTPAuthenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.Header.Get(TokenHeader)
 		if subtle.ConstantTimeCompare([]byte(token), correctAuthenticationToken) == 0 {
-			log.WithField("token", logging.RemoveNewlineSymbol(token)).
+			log.WithContext(r.Context()).
+				WithField("token", logging.RemoveNewlineSymbol(token)).
 				Warn("Incorrect token")
 			w.WriteHeader(http.StatusUnauthorized)
 			return

--- a/internal/api/environments.go
+++ b/internal/api/environments.go
@@ -47,17 +47,17 @@ func (e *EnvironmentController) ConfigureRoutes(router *mux.Router) {
 func (e *EnvironmentController) list(writer http.ResponseWriter, request *http.Request) {
 	fetch, err := parseFetchParameter(request)
 	if err != nil {
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 
 	environments, err := e.manager.List(fetch)
 	if err != nil {
-		writeInternalServerError(writer, err, dto.ErrorUnknown)
+		writeInternalServerError(writer, err, dto.ErrorUnknown, request.Context())
 		return
 	}
 
-	sendJSON(writer, ExecutionEnvironmentsResponse{environments}, http.StatusOK)
+	sendJSON(writer, ExecutionEnvironmentsResponse{environments}, http.StatusOK, request.Context())
 }
 
 // get returns all information about the requested execution environment.
@@ -65,12 +65,12 @@ func (e *EnvironmentController) get(writer http.ResponseWriter, request *http.Re
 	environmentID, err := parseEnvironmentID(request)
 	if err != nil {
 		// This case is never used as the router validates the id format
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 	fetch, err := parseFetchParameter(request)
 	if err != nil {
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 
@@ -79,11 +79,11 @@ func (e *EnvironmentController) get(writer http.ResponseWriter, request *http.Re
 		writer.WriteHeader(http.StatusNotFound)
 		return
 	} else if err != nil {
-		writeInternalServerError(writer, err, dto.ErrorUnknown)
+		writeInternalServerError(writer, err, dto.ErrorUnknown, request.Context())
 		return
 	}
 
-	sendJSON(writer, executionEnvironment, http.StatusOK)
+	sendJSON(writer, executionEnvironment, http.StatusOK, request.Context())
 }
 
 // delete removes the specified execution environment.
@@ -91,13 +91,13 @@ func (e *EnvironmentController) delete(writer http.ResponseWriter, request *http
 	environmentID, err := parseEnvironmentID(request)
 	if err != nil {
 		// This case is never used as the router validates the id format
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 
 	found, err := e.manager.Delete(environmentID)
 	if err != nil {
-		writeInternalServerError(writer, err, dto.ErrorUnknown)
+		writeInternalServerError(writer, err, dto.ErrorUnknown, request.Context())
 		return
 	} else if !found {
 		writer.WriteHeader(http.StatusNotFound)
@@ -111,12 +111,12 @@ func (e *EnvironmentController) delete(writer http.ResponseWriter, request *http
 func (e *EnvironmentController) createOrUpdate(writer http.ResponseWriter, request *http.Request) {
 	req := new(dto.ExecutionEnvironmentRequest)
 	if err := json.NewDecoder(request.Body).Decode(req); err != nil {
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 	environmentID, err := parseEnvironmentID(request)
 	if err != nil {
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return
 	}
 
@@ -125,7 +125,7 @@ func (e *EnvironmentController) createOrUpdate(writer http.ResponseWriter, reque
 		created, err = e.manager.CreateOrUpdate(environmentID, *req, ctx)
 	})
 	if err != nil {
-		writeInternalServerError(writer, err, dto.ErrorUnknown)
+		writeInternalServerError(writer, err, dto.ErrorUnknown, request.Context())
 	}
 
 	if created {

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -1,38 +1,40 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"net/http"
 )
 
-func writeInternalServerError(writer http.ResponseWriter, err error, errorCode dto.ErrorCode) {
-	sendJSON(writer, &dto.InternalServerError{Message: err.Error(), ErrorCode: errorCode}, http.StatusInternalServerError)
+func writeInternalServerError(writer http.ResponseWriter, err error, errorCode dto.ErrorCode, ctx context.Context) {
+	sendJSON(writer, &dto.InternalServerError{Message: err.Error(), ErrorCode: errorCode},
+		http.StatusInternalServerError, ctx)
 }
 
-func writeClientError(writer http.ResponseWriter, err error, status uint16) {
-	sendJSON(writer, &dto.ClientError{Message: err.Error()}, int(status))
+func writeClientError(writer http.ResponseWriter, err error, status uint16, ctx context.Context) {
+	sendJSON(writer, &dto.ClientError{Message: err.Error()}, int(status), ctx)
 }
 
-func sendJSON(writer http.ResponseWriter, content interface{}, httpStatusCode int) {
+func sendJSON(writer http.ResponseWriter, content interface{}, httpStatusCode int, ctx context.Context) {
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(httpStatusCode)
 	response, err := json.Marshal(content)
 	if err != nil {
 		// cannot produce infinite recursive loop, since json.Marshal of dto.InternalServerError won't return an error
-		writeInternalServerError(writer, err, dto.ErrorUnknown)
+		writeInternalServerError(writer, err, dto.ErrorUnknown, ctx)
 		return
 	}
 	if _, err = writer.Write(response); err != nil {
-		log.WithError(err).Error("Could not write JSON response")
+		log.WithError(err).WithContext(ctx).Error("Could not write JSON response")
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
 	}
 }
 
 func parseJSONRequestBody(writer http.ResponseWriter, request *http.Request, structure interface{}) error {
 	if err := json.NewDecoder(request.Body).Decode(structure); err != nil {
-		writeClientError(writer, err, http.StatusBadRequest)
+		writeClientError(writer, err, http.StatusBadRequest, request.Context())
 		return fmt.Errorf("error parsing JSON request body: %w", err)
 	}
 	return nil

--- a/internal/api/ws/codeocean_writer_test.go
+++ b/internal/api/ws/codeocean_writer_test.go
@@ -16,7 +16,7 @@ func TestRawToCodeOceanWriter(t *testing.T) {
 	connectionMock, message := buildConnectionMock(t)
 	proxyCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	output := NewCodeOceanOutputWriter(connectionMock, proxyCtx)
+	output := NewCodeOceanOutputWriter(connectionMock, proxyCtx, cancel)
 	<-message // start message
 
 	t.Run("StdOut", func(t *testing.T) {
@@ -69,10 +69,10 @@ func TestCodeOceanOutputWriter_SendExitInfo(t *testing.T) {
 			connectionMock, message := buildConnectionMock(t)
 			proxyCtx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			output := NewCodeOceanOutputWriter(connectionMock, proxyCtx)
+			output := NewCodeOceanOutputWriter(connectionMock, proxyCtx, cancel)
 			<-message // start message
 
-			output.SendExitInfo(test.info)
+			output.Close(test.info)
 			expected, err := json.Marshal(test.message)
 			require.NoError(t, err)
 

--- a/internal/nomad/api_querier.go
+++ b/internal/nomad/api_querier.go
@@ -94,7 +94,7 @@ func (nc *nomadAPIClient) Execute(runnerID string,
 	ctx context.Context, cmd string, tty bool,
 	stdin io.Reader, stdout, stderr io.Writer,
 ) (int, error) {
-	log.WithField("command", strings.ReplaceAll(cmd, "\n", "")).Trace("Requesting Nomad Exec")
+	log.WithContext(ctx).WithField("command", strings.ReplaceAll(cmd, "\n", "")).Trace("Requesting Nomad Exec")
 	var allocations []*nomadApi.AllocationListStub
 	var err error
 	logging.StartSpan("nomad.execute.list", "List Allocations for id", ctx, func(_ context.Context) {
@@ -132,10 +132,10 @@ func (nc *nomadAPIClient) Execute(runnerID string,
 	case err == nil:
 		return exitCode, nil
 	case websocket.IsCloseError(errors.Unwrap(err), websocket.CloseNormalClosure):
-		log.WithField("runnerID", runnerID).WithError(err).Info("The exit code could not be received.")
+		log.WithContext(ctx).WithField("runnerID", runnerID).WithError(err).Info("The exit code could not be received.")
 		return 0, nil
 	case errors.Is(err, context.Canceled):
-		log.WithField("runnerID", runnerID).Debug("Execution canceled by context")
+		log.WithContext(ctx).WithField("runnerID", runnerID).Debug("Execution canceled by context")
 		return 0, nil
 	default:
 		return 1, fmt.Errorf("error executing command in allocation: %w", err)

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -482,7 +482,7 @@ func (a *APIClient) executeCommandInteractivelyWithStderr(allocationID string, c
 			exit, err := a.Execute(allocationID, ctx, prepareCommandTTYStdErr(currentNanoTime, privilegedExecution), true,
 				nullio.Reader{Ctx: readingContext}, stderr, io.Discard)
 			if err != nil {
-				log.WithError(err).WithField("runner", allocationID).Warn("Stderr task finished with error")
+				log.WithContext(ctx).WithError(err).WithField("runner", allocationID).Warn("Stderr task finished with error")
 			}
 			stderrExitChan <- exit
 		})

--- a/internal/nomad/sentry_debug_writer.go
+++ b/internal/nomad/sentry_debug_writer.go
@@ -56,7 +56,7 @@ func (s *SentryDebugWriter) Write(p []byte) (n int, err error) {
 
 	match := matchAndMapTimeDebugMessage(p)
 	if match == nil {
-		log.WithField("data", p).Warn("Exec debug message could not be read completely")
+		log.WithContext(s.Ctx).WithField("data", p).Warn("Exec debug message could not be read completely")
 		return 0, nil
 	}
 
@@ -93,7 +93,7 @@ func (s *SentryDebugWriter) Close(exitCode int) {
 func (s *SentryDebugWriter) handleTimeDebugMessage(match map[string][]byte) {
 	timestamp, err := strconv.ParseInt(string(match["time"]), 10, 64)
 	if err != nil {
-		log.WithField("match", match).Warn("Could not parse Unix timestamp")
+		log.WithContext(s.Ctx).WithField("match", match).Warn("Could not parse Unix timestamp")
 		return
 	}
 

--- a/internal/runner/aws_runner.go
+++ b/internal/runner/aws_runner.go
@@ -153,7 +153,7 @@ func (w *AWSFunctionWorkload) executeCommand(ctx context.Context, command []stri
 		Cmd:    command,
 		Files:  w.fs,
 	}
-	log.WithField("request", data).Trace("Sending request to AWS")
+	log.WithContext(ctx).WithField("request", data).Trace("Sending request to AWS")
 	rawData, err := json.Marshal(data)
 	if err != nil {
 		exit <- ExitInfo{uint8(1), fmt.Errorf("cannot stingify aws function request: %w", err)}
@@ -202,7 +202,7 @@ func (w *AWSFunctionWorkload) receiveOutput(
 
 		switch wsMessage.Type {
 		default:
-			log.WithField("data", wsMessage).Warn("unexpected message from aws function")
+			log.WithContext(ctx).WithField("data", wsMessage).Warn("unexpected message from aws function")
 		case dto.WebSocketExit:
 			return wsMessage.ExitCode, nil
 		case dto.WebSocketOutputStdout:

--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -134,7 +134,7 @@ func (m *NomadRunnerManager) keepRunnersSynced(ctx context.Context) {
 		err := m.apiClient.WatchEventStream(ctx,
 			&nomad.AllocationProcessoring{OnNew: m.onAllocationAdded, OnDeleted: m.onAllocationStopped})
 		retries += 1
-		log.WithError(err).Errorf("Stopped updating the runners! Retry %v", retries)
+		log.WithContext(ctx).WithError(err).Errorf("Stopped updating the runners! Retry %v", retries)
 		<-time.After(time.Second)
 	}
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -77,7 +77,7 @@ func HTTPLoggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(lrw, r)
 
 		latency := time.Now().UTC().Sub(start)
-		logEntry := log.WithFields(logrus.Fields{
+		logEntry := log.WithContext(r.Context()).WithFields(logrus.Fields{
 			"code":       lrw.StatusCode,
 			"method":     r.Method,
 			"path":       path,

--- a/pkg/logging/sentry_hook.go
+++ b/pkg/logging/sentry_hook.go
@@ -24,7 +24,15 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	event.Level = sentry.Level(entry.Level.String())
 	event.Message = entry.Message
 	event.Extra = entry.Data
-	sentry.CaptureEvent(event)
+
+	var hub *sentry.Hub
+	if entry.Context != nil {
+		hub = sentry.GetHubFromContext(entry.Context)
+	}
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
+	hub.CaptureEvent(event)
 	return nil
 }
 

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -130,12 +130,12 @@ func addEnvironmentID(r *http.Request, id dto.EnvironmentID) {
 func AddRequestSize(r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.WithError(err).Warn("Failed to read request body")
+		log.WithContext(r.Context()).WithError(err).Warn("Failed to read request body")
 	}
 
 	err = r.Body.Close()
 	if err != nil {
-		log.WithError(err).Warn("Failed to close request body")
+		log.WithContext(r.Context()).WithError(err).Warn("Failed to close request body")
 	}
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
 
@@ -185,7 +185,7 @@ func addInfluxDBField(r *http.Request, key string, value interface{}) {
 func dataPointFromRequest(r *http.Request) *write.Point {
 	p, ok := r.Context().Value(influxdbContextKey).(*write.Point)
 	if !ok {
-		log.Error("All http request must contain an influxdb data point!")
+		log.WithContext(r.Context()).Error("All http request must contain an influxdb data point!")
 	}
 	return p
 }

--- a/pkg/nullio/ls2json.go
+++ b/pkg/nullio/ls2json.go
@@ -69,7 +69,7 @@ func (w *Ls2JsonWriter) Write(p []byte) (int, error) {
 		if len(line) != 0 {
 			count, err := w.writeLine(line)
 			if err != nil {
-				log.WithError(err).Warn("Could not write line to Target")
+				log.WithContext(w.Ctx).WithError(err).Warn("Could not write line to Target")
 				return count, err
 			}
 		}
@@ -87,7 +87,7 @@ func (w *Ls2JsonWriter) initializeJSONObject() (count int, err error) {
 	if !w.jsonStartSent {
 		count, err = w.Target.Write([]byte("{\"files\": ["))
 		if count == 0 || err != nil {
-			log.WithError(err).Warn("Could not write to target")
+			log.WithContext(w.Ctx).WithError(err).Warn("Could not write to target")
 			err = fmt.Errorf("could not write to target: %w", err)
 		} else {
 			w.jsonStartSent = true
@@ -102,7 +102,7 @@ func (w *Ls2JsonWriter) Close() {
 	if w.jsonStartSent {
 		count, err := w.Target.Write([]byte("]}"))
 		if count == 0 || err != nil {
-			log.WithError(err).Warn("Could not Close ls2json writer")
+			log.WithContext(w.Ctx).WithError(err).Warn("Could not Close ls2json writer")
 		}
 		w.sentrySpan.Finish()
 	}
@@ -163,7 +163,7 @@ func (w *Ls2JsonWriter) parseFileHeader(matches [][]byte) ([]byte, error) {
 			name = dto.FilePath(parts[0])
 			linkTarget = dto.FilePath(parts[1])
 		} else {
-			log.Error("could not split link into name and target")
+			log.WithContext(w.Ctx).Error("could not split link into name and target")
 		}
 	}
 


### PR DESCRIPTION
Closes #326 

With updating our Sentry Hook, tracing information stored in the passed context can be associated with sentry events/issues.

With this first commit, we added the context just to log statements where an context was available. In many places we do not pass the (request) context. I think it would be a good practice to do so in the future, (not only) because we then could associate Sentry issues with Sentry Traces. We may use this PR for a refactoring into the direction of more context passing.

I noticed, that Sentry developed [its own Logrus Hook](https://github.com/getsentry/sentry-go/blob/master/logrus/logrusentry.go) 4 months ago. We may think about switching to that. At this moment their implementation does not support the tracing association but there is an open PR https://github.com/getsentry/sentry-go/pull/522