### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  notify:
+    after_n_builds: 2
+
+ignore:
+  - "**/*_mock.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: date +%s > ~/.cache/go-build/trim.txt
         continue-on-error: true
       - name: Build
-        run: make build
+        run: make build-cover
       - name: Upload Poseidon binary
         uses: actions/upload-artifact@v3
         with:
@@ -84,19 +84,26 @@ jobs:
         continue-on-error: true
       - name: Run tests
         run: make coverhtml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ success() || failure() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Publish code coverage
         uses: paambaati/codeclimate-action@v3.2.0
+        if: ${{ success() || failure() }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           prefix: github.com/openHPI/poseidon/
           coverageLocations: |
-            ${{github.workspace}}/coverage_cleaned.cov:gocov
+            ${{github.workspace}}/coverage/coverage.cov:gocov
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
+        if: ${{ success() || failure() }}
         with:
           name: coverage
-          path: coverage_unit.html
+          path: coverage/coverage_unit.html
 
   dep-scan:
     runs-on: ubuntu-latest
@@ -130,6 +137,7 @@ jobs:
       POSEIDON_AWS_ENDPOINT: ${{ secrets.POSEIDON_AWS_ENDPOINT }}
       POSEIDON_AWS_FUNCTIONS: ""
       POSEIDON_NOMAD_DISABLEFORCEPULL: true
+      GOCOVERDIR: coverage
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -204,6 +212,7 @@ jobs:
           sudo ./nomad agent -dev -log-level=WARN -config e2e-config.hcl &
           until curl -s --fail http://localhost:4646/v1/agent/health ; do sleep 1; done
           chmod +x ./poseidon
+          mkdir -p ${GOCOVERDIR}
           ./poseidon &
           until curl -s --fail http://localhost:7200/api/v1/health ; do sleep 1; done
           make e2e-test
@@ -211,3 +220,18 @@ jobs:
         run: |
           killall poseidon
           make e2e-test-recovery
+        if: ${{ success() || failure() }}
+      - name: Convert coverage reports
+        run: make convert-run-coverage
+        if: ${{ success() || failure() }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ success() || failure() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        if: ${{ success() || failure() }}
+        with:
+          name: coverage
+          path: coverage/coverage_run.html

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ tests/e2e/configuration.yaml
 # trivy artifacts
 .trivy
 
+# coverage reports
+/coverage
+
 # IDE files
 /.idea
 *.iml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/openHPI/poseidon/actions/workflows/ci.yml/badge.svg)](https://github.com/openHPI/poseidon/actions/workflows/ci.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8a968383173ba81fca18/maintainability)](https://codeclimate.com/github/openHPI/poseidon/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8a968383173ba81fca18/test_coverage)](https://codeclimate.com/github/openHPI/poseidon/test_coverage)
+[![codecov](https://codecov.io/github/openHPI/poseidon/branch/main/graph/badge.svg?token=82CPV7I408)](https://codecov.io/github/openHPI/poseidon)
 
 <img src="assets/Poseidon.svg" alt="Poseidon logo" width="20%">
 


### PR DESCRIPTION
In addition to CodeClimate, I am adding Codecov with this PR and also [add coverage from the e2e-tests using a new feature from Go 1.20](https://go.dev/testing/coverage/).

View the latest coverage report [here](https://app.codecov.io/github/openHPI/poseidon/tree/codecov).

The advantage of Codecov is the integration with Sentry, read more about that integration [here](https://blog.sentry.io/2023/03/29/code-coverage-insights-now-in-your-stack-trace-announcing-our-codecov/). Since [Sentry acquired Codecov in November last year](https://blog.sentry.io/2022/11/30/bringing-codecov-into-the-sentry-family-where-code-coverage-meets-application-monitoring/), I would assume more interesting integrations will arrive.

Once we are satisfied with Codecov, we could remove the CodeClimate integration.