### PR TITLE
Synchronize Sentry debug message handling.

### DIFF
--- a/internal/nomad/sentry_debug_writer.go
+++ b/internal/nomad/sentry_debug_writer.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"regexp"
 	"strconv"
-	"sync"
 	"time"
 )
 
@@ -28,10 +27,9 @@ var (
 // For matches, it creates a Sentry Span. Otherwise, the data will be forwarded to the Target.
 // The passed context Ctx should contain the Sentry data.
 type SentryDebugWriter struct {
-	Target       io.Writer
-	Ctx          context.Context
-	lastSpan     *sentry.Span
-	lastSpanLock sync.Mutex
+	Target   io.Writer
+	Ctx      context.Context
+	lastSpan *sentry.Span
 }
 
 func NewSentryDebugWriter(target io.Writer, ctx context.Context) *SentryDebugWriter {
@@ -66,7 +64,7 @@ func (s *SentryDebugWriter) Write(p []byte) (n int, err error) {
 		n += count
 	}
 
-	go s.handleTimeDebugMessage(match)
+	s.handleTimeDebugMessage(match)
 	n += len(p) - len(match["before"]) - len(match["after"])
 
 	if len(match["after"]) > 0 {
@@ -80,8 +78,6 @@ func (s *SentryDebugWriter) Write(p []byte) (n int, err error) {
 
 func (s *SentryDebugWriter) Close(exitCode int) {
 	if s.lastSpan != nil {
-		s.lastSpanLock.Lock()
-		defer s.lastSpanLock.Unlock()
 		s.lastSpan.Op = "nomad.execute.disconnect"
 		s.lastSpan.SetTag("exit_code", strconv.Itoa(exitCode))
 		s.lastSpan.Finish()
@@ -97,8 +93,6 @@ func (s *SentryDebugWriter) handleTimeDebugMessage(match map[string][]byte) {
 		return
 	}
 
-	s.lastSpanLock.Lock()
-	defer s.lastSpanLock.Unlock()
 	if s.lastSpan != nil {
 		s.lastSpan.EndTime = time.UnixMilli(timestamp)
 		s.lastSpan.SetData("latency", time.Since(time.UnixMilli(timestamp)).String())


### PR DESCRIPTION
Closes #354

In order to guarantee the order of the debug messages, we can handle the debug messages synchronous to the Write calls, as we expect the write calls to be in the right order.

We may even remove the Mutex?!