### PR TITLE
Add Job ID to Nomad Allocation monitoring.

### DIFF
--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -35,6 +35,7 @@ const (
 
 	InfluxKeyRunnerID                      = "runner_id"
 	InfluxKeyEnvironmentID                 = "environment_id"
+	InfluxKeyJobID                         = "job_id"
 	InfluxKeyActualContentLength           = "actual_length"
 	InfluxKeyExpectedContentLength         = "expected_length"
 	InfluxKeyDuration                      = "duration"


### PR DESCRIPTION
Related to #358 and #357 

In order to combine the monitoring information with the Poseidon logs we need to identify the allocation transactions with its job ID (and not only its allocation ID).