### PR TITLE
Add Client Status to Nomad Allocation monitoring.

### DIFF
--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -37,6 +37,8 @@ const (
 	InfluxKeyRunnerID                      = "runner_id"
 	InfluxKeyEnvironmentID                 = "environment_id"
 	InfluxKeyJobID                         = "job_id"
+	InfluxKeyClientStatus                  = "client_status"
+	InfluxKeyNomadNode                     = "nomad_agent"
 	InfluxKeyActualContentLength           = "actual_length"
 	InfluxKeyExpectedContentLength         = "expected_length"
 	InfluxKeyDuration                      = "duration"


### PR DESCRIPTION
It would also be great to see the client status in the monitoring data. Sorry for putting this in a separate PR :sweat_smile: 