### PR TITLE
Monitor the Nomad events

### DIFF
--- a/internal/nomad/api_querier.go
+++ b/internal/nomad/api_querier.go
@@ -181,6 +181,9 @@ func (nc *nomadAPIClient) EventStream(ctx context.Context) (<-chan *nomadApi.Eve
 				// As Poseidon uses no such token, the request will return a permission denied error.
 				"*",
 			},
+			nomadApi.TopicJob:        {"*"},
+			nomadApi.TopicNode:       {"*"},
+			nomadApi.TopicDeployment: {"*"},
 		},
 		0,
 		nc.queryOptions())

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -23,6 +23,7 @@ const (
 	// measurementPrefix allows easier filtering in influxdb.
 	measurementPrefix           = "poseidon_"
 	measurementPoolSize         = measurementPrefix + "poolsize"
+	MeasurementNomadEvents      = measurementPrefix + "nomad_events"
 	MeasurementNomadAllocations = measurementPrefix + "nomad_allocations"
 	MeasurementIdleRunnerNomad  = measurementPrefix + "nomad_idle_runners"
 	MeasurementExecutionsAWS    = measurementPrefix + "aws_executions"


### PR DESCRIPTION
and send all Nomad events to Influxdb.

In https://github.com/openHPI/poseidon/issues/358#issuecomment-1537218034 we assumed the handling of the Nomad events cause #358. In order to verify and fix this issue, we need to verify which events we (don't) get. In order not to flood the Poseidon log, we dump those events to Influxdb in the hope that it can handle that.. What do you think?