### PR TITLE
Fix missing idle runners.

### DIFF
--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -509,16 +509,31 @@ func TestApiClient_WatchAllocationsHandlesEvents(t *testing.T) {
 }
 
 func TestHandleAllocationEventBuffersPendingAllocation(t *testing.T) {
-	newPendingAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusRun)
-	newPendingEvent := eventForAllocation(t, newPendingAllocation)
+	t.Run("AllocationUpdated", func(t *testing.T) {
+		newPendingAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusRun)
+		newPendingEvent := eventForAllocation(t, newPendingAllocation)
 
-	allocations := storage.NewLocalStorage[*allocationData]()
-	err := handleAllocationEvent(
-		time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessoring)
-	require.NoError(t, err)
+		allocations := storage.NewLocalStorage[*allocationData]()
+		err := handleAllocationEvent(
+			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessoring)
+		require.NoError(t, err)
 
-	_, ok := allocations.Get(newPendingAllocation.ID)
-	assert.True(t, ok)
+		_, ok := allocations.Get(newPendingAllocation.ID)
+		assert.True(t, ok)
+	})
+	t.Run("PlanResult", func(t *testing.T) {
+		newPendingAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusRun)
+		newPendingEvent := eventForAllocation(t, newPendingAllocation)
+		newPendingEvent.Type = structs.TypePlanResult
+
+		allocations := storage.NewLocalStorage[*allocationData]()
+		err := handleAllocationEvent(
+			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessoring)
+		require.NoError(t, err)
+
+		_, ok := allocations.Get(newPendingAllocation.ID)
+		assert.True(t, ok)
+	})
 }
 
 func TestAPIClient_WatchAllocationsReturnsErrorWhenAllocationStreamCannotBeRetrieved(t *testing.T) {


### PR DESCRIPTION
Related to #358 

The idle runner decrease from time to time as the Nomad event `AllocationUpdated` with the status `pending` is common but not always send and our process relied on it.

Automatic merge and deployment this night.