### PR TITLE
Monitor Job events

### DIFF
--- a/internal/nomad/api_querier.go
+++ b/internal/nomad/api_querier.go
@@ -181,6 +181,7 @@ func (nc *nomadAPIClient) EventStream(ctx context.Context) (<-chan *nomadApi.Eve
 				// As Poseidon uses no such token, the request will return a permission denied error.
 				"*",
 			},
+			nomadApi.TopicJob: {"*"},
 		},
 		0,
 		nc.queryOptions())

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -235,6 +235,7 @@ func dumpNomadEventToInflux(event *nomadApi.Event) {
 	p.AddTag("type", event.Type)
 	p.AddTag("key", event.Key)
 	p.AddField("payload", event.Payload)
+	p.AddTag("time", time.Now().Format("03:04:05.000000000"))
 	monitoring.WriteInfluxPoint(p)
 }
 


### PR DESCRIPTION
and add time to Nomad event monitoring.

Related to #358 

If we think about refactoring the Nomad event handling to listen to the `Job` event sometime, we should use the current situation, to collect some data about those events.
