### PR TITLE
Debug/#358 log nomad events

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -235,7 +235,7 @@ func dumpNomadEventToInflux(event *nomadApi.Event) {
 	p.AddTag("type", event.Type)
 	p.AddTag("key", event.Key)
 	p.AddField("payload", event.Payload)
-	p.AddTag("time", time.Now().Format("03:04:05.000000000"))
+	p.AddTag("timestamp", time.Now().Format("03:04:05.000000000"))
 	monitoring.WriteInfluxPoint(p)
 }
 


### PR DESCRIPTION
We assume that influxdb cannot deal with the "time" tag key and deletes the whole batch of data containing this tag key.