### PR TITLE
Fix increased prewarming pool size

### DIFF
--- a/internal/nomad/executor_api_mock.go
+++ b/internal/nomad/executor_api_mock.go
@@ -343,11 +343,11 @@ func (_m *ExecutorAPIMock) SetJobScale(jobID string, count uint, reason string) 
 }
 
 // WatchEventStream provides a mock function with given fields: ctx, callbacks
-func (_m *ExecutorAPIMock) WatchEventStream(ctx context.Context, callbacks *AllocationProcessoring) error {
+func (_m *ExecutorAPIMock) WatchEventStream(ctx context.Context, callbacks *AllocationProcessing) error {
 	ret := _m.Called(ctx, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *AllocationProcessoring) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *AllocationProcessing) error); ok {
 		r0 = rf(ctx, callbacks)
 	} else {
 		r0 = ret.Error(0)

--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -233,7 +233,7 @@ func (s *ManagerTestSuite) TestUpdateRunnersAddsIdleRunner() {
 
 	modifyMockedCall(s.apiMock, "WatchEventStream", func(call *mock.Call) {
 		call.Run(func(args mock.Arguments) {
-			callbacks, ok := args.Get(1).(*nomad.AllocationProcessoring)
+			callbacks, ok := args.Get(1).(*nomad.AllocationProcessing)
 			s.Require().True(ok)
 			callbacks.OnNew(allocation, 0)
 			call.ReturnArguments = mock.Arguments{nil}
@@ -259,11 +259,12 @@ func (s *ManagerTestSuite) TestUpdateRunnersRemovesIdleAndUsedRunner() {
 	environment.AddRunner(testRunner)
 	s.nomadRunnerManager.usedRunners.Add(testRunner.ID(), testRunner)
 
+	s.apiMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 	modifyMockedCall(s.apiMock, "WatchEventStream", func(call *mock.Call) {
 		call.Run(func(args mock.Arguments) {
-			callbacks, ok := args.Get(1).(*nomad.AllocationProcessoring)
+			callbacks, ok := args.Get(1).(*nomad.AllocationProcessing)
 			s.Require().True(ok)
-			callbacks.OnDeleted(allocation)
+			callbacks.OnDeleted(allocation, true)
 			call.ReturnArguments = mock.Arguments{nil}
 		})
 	})


### PR DESCRIPTION
that is caused by all rescheduled allocations being added as idle runners including the used ones.