### PR TITLE
Manually handle allocation restart

### DIFF
--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -46,6 +46,7 @@ job "template-0" {
       }
 
       restart {
+        attempts = 0
         delay = "0s"
       }
     }

--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -22,6 +22,14 @@ job "template-0" {
       attribute = "${node.unique.name}"
       weight = 100
     }
+    restart {
+      attempts = 0
+      delay = "0s"
+    }
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
 
     task "default-task" {
       driver = "docker"
@@ -43,11 +51,6 @@ job "template-0" {
       resources {
         cpu    = 40
         memory = 30
-      }
-
-      restart {
-        attempts = 0
-        delay = "0s"
       }
     }
   }

--- a/internal/nomad/executor_api_mock.go
+++ b/internal/nomad/executor_api_mock.go
@@ -343,11 +343,11 @@ func (_m *ExecutorAPIMock) SetJobScale(jobID string, count uint, reason string) 
 }
 
 // WatchEventStream provides a mock function with given fields: ctx, callbacks
-func (_m *ExecutorAPIMock) WatchEventStream(ctx context.Context, callbacks *AllocationProcessoring) error {
+func (_m *ExecutorAPIMock) WatchEventStream(ctx context.Context, callbacks *AllocationProcessing) error {
 	ret := _m.Called(ctx, callbacks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *AllocationProcessoring) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *AllocationProcessing) error); ok {
 		r0 = rf(ctx, callbacks)
 	} else {
 		r0 = ret.Error(0)

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -32,13 +32,13 @@ var (
 // resultChannelWriteTimeout is to detect the error when more element are written into a channel than expected.
 const resultChannelWriteTimeout = 10 * time.Millisecond
 
-// AllocationProcessoring includes the callbacks to interact with allcoation events.
-type AllocationProcessoring struct {
-	OnNew     AllocationProcessorMonitored
-	OnDeleted AllocationProcessor
+// AllocationProcessing includes the callbacks to interact with allocation events.
+type AllocationProcessing struct {
+	OnNew     NewAllocationProcessor
+	OnDeleted DeletedAllocationProcessor
 }
-type AllocationProcessor func(*nomadApi.Allocation)
-type AllocationProcessorMonitored func(*nomadApi.Allocation, time.Duration)
+type DeletedAllocationProcessor func(alloc *nomadApi.Allocation, failed bool)
+type NewAllocationProcessor func(*nomadApi.Allocation, time.Duration)
 
 type allocationData struct {
 	// allocClientStatus defines the state defined by Nomad.
@@ -79,7 +79,7 @@ type ExecutorAPI interface {
 	// WatchEventStream listens on the Nomad event stream for allocation and evaluation events.
 	// Depending on the incoming event, any of the given function is executed.
 	// Do not run multiple times simultaneously.
-	WatchEventStream(ctx context.Context, callbacks *AllocationProcessoring) error
+	WatchEventStream(ctx context.Context, callbacks *AllocationProcessing) error
 
 	// ExecuteCommand executes the given command in the job/runner with the given id.
 	// It writes the output of the command to stdout/stderr and reads input from stdin.
@@ -187,9 +187,9 @@ func (a *APIClient) MonitorEvaluation(evaluationID string, ctx context.Context) 
 		defer cancel() // cancel the WatchEventStream when the evaluation result was read.
 
 		go func() {
-			err = a.WatchEventStream(ctx, &AllocationProcessoring{
+			err = a.WatchEventStream(ctx, &AllocationProcessing{
 				OnNew:     func(_ *nomadApi.Allocation, _ time.Duration) {},
-				OnDeleted: func(_ *nomadApi.Allocation) {},
+				OnDeleted: func(_ *nomadApi.Allocation, _ bool) {},
 			})
 			cancel() // cancel the waiting for an evaluation result if watching the event stream ends.
 		}()
@@ -204,7 +204,7 @@ func (a *APIClient) MonitorEvaluation(evaluationID string, ctx context.Context) 
 	}
 }
 
-func (a *APIClient) WatchEventStream(ctx context.Context, callbacks *AllocationProcessoring) error {
+func (a *APIClient) WatchEventStream(ctx context.Context, callbacks *AllocationProcessing) error {
 	startTime := time.Now().UnixNano()
 	stream, err := a.EventStream(ctx)
 	if err != nil {
@@ -318,7 +318,7 @@ func handleEvaluationEvent(evaluations map[string]chan error, event *nomadApi.Ev
 // is called. The allocations storage is used to track pending and running allocations. Using the
 // storage the state is persisted between multiple calls of this function.
 func handleAllocationEvent(startTime int64, allocations storage.Storage[*allocationData],
-	event *nomadApi.Event, callbacks *AllocationProcessoring) error {
+	event *nomadApi.Event, callbacks *AllocationProcessing) error {
 	alloc, err := event.Allocation()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve allocation from event: %w", err)
@@ -340,13 +340,13 @@ func handleAllocationEvent(startTime int64, allocations storage.Storage[*allocat
 
 	switch alloc.ClientStatus {
 	case structs.AllocClientStatusPending:
-		handlePendingAllocationEvent(alloc, allocations, callbacks)
+		handlePendingAllocationEvent(alloc, allocations)
 	case structs.AllocClientStatusRunning:
 		handleRunningAllocationEvent(alloc, allocations, callbacks)
 	case structs.AllocClientStatusComplete:
 		handleCompleteAllocationEvent(alloc, allocations, callbacks)
 	case structs.AllocClientStatusFailed:
-		handleFailedAllocationEvent(alloc)
+		handleFailedAllocationEvent(alloc, allocations, callbacks)
 	default:
 		log.WithField("alloc", alloc).Warn("Other Client Status")
 	}
@@ -355,8 +355,7 @@ func handleAllocationEvent(startTime int64, allocations storage.Storage[*allocat
 
 // handlePendingAllocationEvent manages allocation that are currently pending.
 // This allows the handling of startups and re-placements of allocations.
-func handlePendingAllocationEvent(alloc *nomadApi.Allocation,
-	allocations storage.Storage[*allocationData], callbacks *AllocationProcessoring) {
+func handlePendingAllocationEvent(alloc *nomadApi.Allocation, allocations storage.Storage[*allocationData]) {
 	if alloc.DesiredStatus == structs.AllocDesiredStatusRun {
 		allocData, ok := allocations.Get(alloc.ID)
 		if ok && allocData.allocClientStatus != structs.AllocClientStatusRunning {
@@ -366,8 +365,10 @@ func handlePendingAllocationEvent(alloc *nomadApi.Allocation,
 			// We are just interested in the first event, in order to have the correct start time.
 			return
 		} else if ok {
-			// Handle Runner (/Container) re-allocations.
-			callbacks.OnDeleted(alloc)
+			// Case: Runner (/Container) re-allocations.
+			// It should not occur as we define the Nomad Job Specification to not restart allocations.
+			log.WithField("alloc", alloc).Error("Runner re-allocation")
+			return
 		}
 		// Store Pending Allocation - Allocation gets started, wait until it runs.
 		allocations.Add(alloc.ID, &allocationData{
@@ -381,9 +382,9 @@ func handlePendingAllocationEvent(alloc *nomadApi.Allocation,
 	}
 }
 
-// handleRunningAllocationEvent calls the passed AllocationProcessor filtering similar events.
+// handleRunningAllocationEvent calls the passed AllocationProcessing filtering similar events.
 func handleRunningAllocationEvent(alloc *nomadApi.Allocation,
-	allocations storage.Storage[*allocationData], callbacks *AllocationProcessoring) {
+	allocations storage.Storage[*allocationData], callbacks *AllocationProcessing) {
 	if alloc.DesiredStatus == structs.AllocDesiredStatusRun {
 		// is first event that marks the transition between pending and running?
 		if allocData, ok := allocations.Get(alloc.ID); ok && allocData.allocClientStatus == structs.AllocClientStatusPending {
@@ -396,10 +397,10 @@ func handleRunningAllocationEvent(alloc *nomadApi.Allocation,
 
 // handleCompleteAllocationEvent handles allocations that stopped.
 func handleCompleteAllocationEvent(alloc *nomadApi.Allocation,
-	allocations storage.Storage[*allocationData], callbacks *AllocationProcessoring) {
+	allocations storage.Storage[*allocationData], callbacks *AllocationProcessing) {
 	if alloc.DesiredStatus == structs.AllocDesiredStatusStop {
 		if _, ok := allocations.Get(alloc.ID); ok {
-			callbacks.OnDeleted(alloc)
+			callbacks.OnDeleted(alloc, false)
 			allocations.Delete(alloc.ID)
 		}
 	} else {
@@ -408,12 +409,18 @@ func handleCompleteAllocationEvent(alloc *nomadApi.Allocation,
 }
 
 // handleFailedAllocationEvent logs only the first of the multiple failure events.
-func handleFailedAllocationEvent(alloc *nomadApi.Allocation) {
-	if alloc.FollowupEvalID == "" && alloc.PreviousAllocation == "" {
-		log.WithField("job", alloc.JobID).
-			WithField("reason", failureDisplayMessage(alloc)).
-			WithField("alloc", alloc).
-			Warn("Allocation failure")
+func handleFailedAllocationEvent(alloc *nomadApi.Allocation,
+	allocations storage.Storage[*allocationData], callbacks *AllocationProcessing) {
+	entry := log.WithField("job", alloc.JobID).
+		WithField("reason", failureDisplayMessage(alloc)).
+		WithField("alloc", alloc)
+
+	if _, ok := allocations.Get(alloc.ID); ok {
+		callbacks.OnDeleted(alloc, true)
+		allocations.Delete(alloc.ID)
+		entry.Warn("Allocation failure")
+	} else {
+		log.Debug("Duplicate Allocation Failure event")
 	}
 }
 

--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	noopAllocationProcessoring = &AllocationProcessoring{
+	noopAllocationProcessing = &AllocationProcessing{
 		OnNew:     func(_ *nomadApi.Allocation, _ time.Duration) {},
-		OnDeleted: func(_ *nomadApi.Allocation) {},
+		OnDeleted: func(_ *nomadApi.Allocation, _ bool) {},
 	}
 	ErrUnexpectedEOF = errors.New("unexpected EOF")
 )
@@ -495,9 +495,9 @@ func TestApiClient_WatchAllocationsHandlesEvents(t *testing.T) {
 			[]*nomadApi.Allocation{newStoppedAllocation},
 			"it adds and deletes the allocation"},
 		{[]*nomadApi.Events{&startAllocationEvents, &startAllocationEvents},
-			[]*nomadApi.Allocation{newStartedAllocation, newStartedAllocation},
-			[]*nomadApi.Allocation{newPendingAllocation},
-			"it handles multiple events"},
+			[]*nomadApi.Allocation{newStartedAllocation},
+			[]*nomadApi.Allocation(nil),
+			"it ignores allocation restarts"},
 	}
 
 	for _, c := range cases {
@@ -515,7 +515,7 @@ func TestHandleAllocationEventBuffersPendingAllocation(t *testing.T) {
 
 		allocations := storage.NewLocalStorage[*allocationData]()
 		err := handleAllocationEvent(
-			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessoring)
+			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessing)
 		require.NoError(t, err)
 
 		_, ok := allocations.Get(newPendingAllocation.ID)
@@ -528,7 +528,7 @@ func TestHandleAllocationEventBuffersPendingAllocation(t *testing.T) {
 
 		allocations := storage.NewLocalStorage[*allocationData]()
 		err := handleAllocationEvent(
-			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessoring)
+			time.Now().UnixNano(), allocations, &newPendingEvent, noopAllocationProcessing)
 		require.NoError(t, err)
 
 		_, ok := allocations.Get(newPendingAllocation.ID)
@@ -541,7 +541,7 @@ func TestAPIClient_WatchAllocationsReturnsErrorWhenAllocationStreamCannotBeRetri
 	apiMock.On("EventStream", mock.Anything).Return(nil, tests.ErrDefault)
 	apiClient := &APIClient{apiMock, map[string]chan error{}, storage.NewLocalStorage[*allocationData](), false}
 
-	err := apiClient.WatchEventStream(context.Background(), noopAllocationProcessoring)
+	err := apiClient.WatchEventStream(context.Background(), noopAllocationProcessing)
 	assert.ErrorIs(t, err, tests.ErrDefault)
 }
 
@@ -557,14 +557,14 @@ func TestAPIClient_WatchAllocationsReturnsErrorWhenAllocationCannotBeRetrievedWi
 	require.Error(t, err)
 
 	events := []*nomadApi.Events{{Events: []nomadApi.Event{event}}, {}}
-	eventsProcessed, err := runAllocationWatching(t, events, noopAllocationProcessoring)
+	eventsProcessed, err := runAllocationWatching(t, events, noopAllocationProcessing)
 	assert.Error(t, err)
 	assert.Equal(t, 1, eventsProcessed)
 }
 
 func TestAPIClient_WatchAllocationsReturnsErrorOnUnexpectedEOF(t *testing.T) {
 	events := []*nomadApi.Events{{Err: ErrUnexpectedEOF}, {}}
-	eventsProcessed, err := runAllocationWatching(t, events, noopAllocationProcessoring)
+	eventsProcessed, err := runAllocationWatching(t, events, noopAllocationProcessing)
 	assert.Error(t, err)
 	assert.Equal(t, 1, eventsProcessed)
 }
@@ -574,11 +574,11 @@ func assertWatchAllocation(t *testing.T, events []*nomadApi.Events,
 	t.Helper()
 	var newAllocations []*nomadApi.Allocation
 	var deletedAllocations []*nomadApi.Allocation
-	callbacks := &AllocationProcessoring{
+	callbacks := &AllocationProcessing{
 		OnNew: func(alloc *nomadApi.Allocation, _ time.Duration) {
 			newAllocations = append(newAllocations, alloc)
 		},
-		OnDeleted: func(alloc *nomadApi.Allocation) {
+		OnDeleted: func(alloc *nomadApi.Allocation, _ bool) {
 			deletedAllocations = append(deletedAllocations, alloc)
 		},
 	}
@@ -594,7 +594,7 @@ func assertWatchAllocation(t *testing.T, events []*nomadApi.Events,
 // runAllocationWatching simulates events streamed from the Nomad event stream
 // to the MonitorEvaluation method. It starts the MonitorEvaluation function as a goroutine
 // and sequentially transfers the events from the given array to a channel simulating the stream.
-func runAllocationWatching(t *testing.T, events []*nomadApi.Events, callbacks *AllocationProcessoring) (
+func runAllocationWatching(t *testing.T, events []*nomadApi.Events, callbacks *AllocationProcessing) (
 	eventsProcessed int, err error) {
 	t.Helper()
 	stream := make(chan *nomadApi.Events)
@@ -606,7 +606,7 @@ func runAllocationWatching(t *testing.T, events []*nomadApi.Events, callbacks *A
 // runs the MonitorEvaluation method in a goroutine. The mock returns a read-only
 // version of the given stream to simulate an event stream gotten from the real
 // Nomad API.
-func asynchronouslyWatchAllocations(stream chan *nomadApi.Events, callbacks *AllocationProcessoring) chan error {
+func asynchronouslyWatchAllocations(stream chan *nomadApi.Events, callbacks *AllocationProcessing) chan error {
 	ctx := context.Background()
 	// We can only get a read-only channel once we return it from a function.
 	readOnlyStream := func() <-chan *nomadApi.Events { return stream }()

--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -233,7 +233,7 @@ func (s *ManagerTestSuite) TestUpdateRunnersAddsIdleRunner() {
 
 	modifyMockedCall(s.apiMock, "WatchEventStream", func(call *mock.Call) {
 		call.Run(func(args mock.Arguments) {
-			callbacks, ok := args.Get(1).(*nomad.AllocationProcessoring)
+			callbacks, ok := args.Get(1).(*nomad.AllocationProcessing)
 			s.Require().True(ok)
 			callbacks.OnNew(allocation, 0)
 			call.ReturnArguments = mock.Arguments{nil}
@@ -261,9 +261,9 @@ func (s *ManagerTestSuite) TestUpdateRunnersRemovesIdleAndUsedRunner() {
 
 	modifyMockedCall(s.apiMock, "WatchEventStream", func(call *mock.Call) {
 		call.Run(func(args mock.Arguments) {
-			callbacks, ok := args.Get(1).(*nomad.AllocationProcessoring)
+			callbacks, ok := args.Get(1).(*nomad.AllocationProcessing)
 			s.Require().True(ok)
-			callbacks.OnDeleted(allocation)
+			callbacks.OnDeleted(allocation, false)
 			call.ReturnArguments = mock.Arguments{nil}
 		})
 	})


### PR DESCRIPTION
Refactor Allocation restart to move the responsibility of restarting allocations from Nomad to Poseidon.

The main focus of this PR is to handle restarts of the Docker service. The restart leads to all container being stopped. With this PR we stop Nomad from restarting these containers in order to do it by ourselves. We want this control because we only want to restart the idle runners and not already used runners.

We restart only every failed, not-used allocation of environments that has idle runners (/ at least one successful runner). This catches allocation failures due to the job specification (such as inaccessible Docker image).
Other causes of failed allocation will be handled by the `util.RetryExponential` functionality of the `Sample` limiting the number of retries to 18.

Related to #358
Replaces #381 