### PR TITLE
Fix decreased prewarming pool due to inactivity timer

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -190,8 +190,11 @@ func (m *NomadRunnerManager) onAllocationStopped(runnerID string) (alreadyRemove
 		return false
 	}
 
-	_, stillActive := m.usedRunners.Get(runnerID)
-	m.usedRunners.Delete(runnerID)
+	r, stillActive := m.usedRunners.Get(runnerID)
+	if stillActive {
+		r.StopTimeout()
+		m.usedRunners.Delete(runnerID)
+	}
 
 	environment, ok := m.environments.Get(environmentID.ToString())
 	if ok {


### PR DESCRIPTION
Related to #358 

Currently we observe some runners being `OOM Killed` (just) in the Poseidon logs (Lack of Error reporting or ok?). This leads to the runner being restarted and added to the idle runners again (even if it was used before the restart). In this case [POSEIDON-2N ](https://codeocean.sentry.io/issues/4220082532)`Too many idle runner` is expected for each restarted and re-added runner.

In this process we could identify two weaknesses:

1. We observed that the WebSocket connections for in that moment running executions are not directly stopped but ran into the execution timeout (of 30 seconds). In these 30 seconds much could happen. I.e. the runner gets restarted, re-added to the idle runners, and re-assigned to another user. When the WebSocket connection the got cancelled (due to the timeout), CodeOcean removes this runner. But, this runner now already belongs to another user.
Worst Case: The used runner gets removed and the other user has to request again a runner for execution.
I haven't found a concrete case for this scenario but the found cases convince me of the possibility.
2. Another case we have found is the case of runner `29-4dbd13a6-0acd-11ee-a4f7-fa163e079f19` that we fix with this PR. This case points out the bug that the inactivity timer is not stopped when the runner is restarted on a failure. The restart adds the runner to the prewarming pool again, but when the not-stopped timer expires the idle runner is removed again.

