### PR TITLE
Insert debug message into execution tracing

### DIFF
--- a/internal/nomad/sentry_debug_writer.go
+++ b/internal/nomad/sentry_debug_writer.go
@@ -11,8 +11,10 @@ import (
 )
 
 var (
+	// debugTimeDebugMessageFormat adds additional information for debugging the bug #325.
+	debugTimeDebugMessageFormat = ` || (echo -n \"\$? \"; ps aux)`
 	// timeDebugMessageFormat is the format of messages that will be converted to debug messages.
-	timeDebugMessageFormat = `echo -ne "\x1EPoseidon %s $(date +%%s%%3N)\x1E"`
+	timeDebugMessageFormat = `echo -ne "\x1EPoseidon %s $(date +%%s%%3N` + debugTimeDebugMessageFormat + `)\x1E"`
 	// Format Parameters: 1. Debug Comment, 2. command.
 	timeDebugMessageFormatStart = timeDebugMessageFormat + `; %s`
 	// Format Parameters: 1. command, 2. Debug Comment.


### PR DESCRIPTION
to verify that the date command is sometimes returning an empty string with exit code 5.

Related to #325 