### PR TITLE
Refactor Runner Destroy Reason Masking

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -189,15 +189,6 @@ func (m *NomadRunnerManager) onAllocationStopped(runnerID string, reason error) 
 
 	r, stillActive := m.usedRunners.Get(runnerID)
 	if stillActive {
-		// Mask the internal stop reason because the runner might disclose/forward it to CodeOcean/externally.
-		switch {
-		case errors.Is(reason, nomad.ErrorOOMKilled):
-			reason = ErrOOMKilled
-		default:
-			log.WithField(dto.KeyRunnerID, runnerID).WithField("reason", reason).Debug("Internal reason for allocation stop")
-			reason = ErrAllocationStopped
-		}
-
 		m.usedRunners.Delete(runnerID)
 		if err := r.Destroy(reason); err != nil {
 			log.WithError(err).Warn("Runner of stopped allocation cannot be destroyed")


### PR DESCRIPTION
and ignore expected reasons such when the runner got destroyed by an API request.

As we have seen with [`POSEIDON-2Y`](https://codeocean.sentry.io/issues/4330986806), we are logging that `the client wants to stop the runner`. This is a false positive warning. With this PR we filter these reasons from throwing a warning.