### PR TITLE
Add Sentry Fingerprint

### DIFF
--- a/pkg/logging/sentry_hook.go
+++ b/pkg/logging/sentry_hook.go
@@ -17,6 +17,7 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 	event.Timestamp = entry.Time
 	event.Level = sentry.Level(entry.Level.String())
 	event.Message = entry.Message
+	event.Fingerprint = []string{"{{ default }}", event.Message}
 
 	// Add Stack Trace when an error was passed.
 	if data, ok := entry.Data["error"]; ok {
@@ -25,6 +26,7 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 			const maxErrorDepth = 10
 			event.SetException(err, maxErrorDepth)
 			entry.Data["error"] = err.Error()
+			event.Fingerprint = append(event.Fingerprint, err.Error())
 		}
 	}
 


### PR DESCRIPTION
for more precise issue grouping.

Sentry's [Issue Grouping](https://docs.sentry.io/product/data-management-settings/event-grouping/) groups many events into some groups defined by characteristics such as the message or the stack trace.
After #412 we have the problem that too many events are grouped together as all events share the top of the stack trace (as they all are created in the Sentry Hook).
But also before #412, the the issue grouping did not allow correct differentiation between different causes. I.e. [`POSEIDON-Z`](https://codeocean.sentry.io/issues/2873411572) groups all issues where an Poseidon execution fails. But, as indicated by the error this might be due to various reasons.

In this PR we make use of the `Fingerprint` attribute, to indicate that the grouping should include the message and the error.