### PR TITLE
Fix/#325 incomplete debug message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
       POSEIDON_AWS_ENABLED: false
       POSEIDON_AWS_ENDPOINT: ${{ secrets.POSEIDON_AWS_ENDPOINT }}
       POSEIDON_AWS_FUNCTIONS: ""
+      POSEIDON_LOGGER_FORMATTER: "JSONFormatter"
+      POSEIDON_LOG_FILE: "../../poseidon.log"
       POSEIDON_NOMAD_DISABLEFORCEPULL: true
       GOCOVERDIR: coverage
     steps:
@@ -204,7 +206,7 @@ jobs:
           until curl -s --fail http://localhost:4646/v1/agent/health ; do sleep 1; done
           chmod +x ./poseidon
           mkdir -p ${GOCOVERDIR}
-          ./poseidon &
+          ./poseidon | tee poseidon.log &
           until curl -s --fail http://localhost:7200/api/v1/health ; do sleep 1; done
           make e2e-test
       - name: Run e2e recovery tests

--- a/cmd/poseidon/main.go
+++ b/cmd/poseidon/main.go
@@ -230,7 +230,7 @@ func main() {
 	if err := config.InitConfig(); err != nil {
 		log.WithError(err).Warn("Could not initialize configuration")
 	}
-	logging.InitializeLogging(config.Config.Logger.Level)
+	logging.InitializeLogging(config.Config.Logger.Level, config.Config.Logger.Formatter)
 	initSentry(&config.Config.Sentry, config.Config.Profiling.Enabled)
 
 	cancelInflux := monitoring.InitializeInfluxDB(&config.Config.InfluxDB)

--- a/internal/api/websocket.go
+++ b/internal/api/websocket.go
@@ -65,6 +65,7 @@ func (wp *webSocketProxy) waitForExit(exit <-chan runner.ExitInfo, cancelExecuti
 	case <-wp.ctx.Done():
 		log.WithContext(wp.ctx).Info("Client closed the connection")
 		wp.Input.Stop()
+		wp.Output.Close(nil)
 		cancelExecution()
 		<-exit // /internal/runner/runner.go handleExitOrContextDone does not require client connection anymore.
 		<-exit // The goroutine closes this channel indicating that it does not use the connection to the executor anymore.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/getsentry/sentry-go"
+	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/pkg/logging"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -50,8 +51,9 @@ var (
 			Endpoint:  "",
 			Functions: []string{},
 		},
-		Logger: logger{
-			Level: "INFO",
+		Logger: Logger{
+			Level:     "INFO",
+			Formatter: dto.FormatterText,
 		},
 		Sentry: sentry.ClientOptions{
 			AttachStacktrace: true,
@@ -120,9 +122,10 @@ type TLS struct {
 	KeyFile  string
 }
 
-// logger configures the used logger.
-type logger struct {
-	Level string
+// Logger configures the used Logger.
+type Logger struct {
+	Formatter dto.Formatter
+	Level     string
 }
 
 // Profiling configures the usage of a runtime profiler to create optimized binaries.
@@ -145,7 +148,7 @@ type configuration struct {
 	Server    server
 	Nomad     Nomad
 	AWS       AWS
-	Logger    logger
+	Logger    Logger
 	Profiling Profiling
 	Sentry    sentry.ClientOptions
 	InfluxDB  InfluxDB

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,7 +33,7 @@ func newTestConfiguration() *configuration {
 				Active: false,
 			},
 		},
-		Logger: logger{
+		Logger: Logger{
 			Level: "INFO",
 		},
 	}

--- a/internal/nomad/sentry_debug_writer.go
+++ b/internal/nomad/sentry_debug_writer.go
@@ -11,10 +11,8 @@ import (
 )
 
 var (
-	// debugTimeDebugMessageFormat adds additional information for debugging the bug #325.
-	debugTimeDebugMessageFormat = ` || (echo -n \"\$? \"; ps aux)`
 	// timeDebugMessageFormat is the format of messages that will be converted to debug messages.
-	timeDebugMessageFormat = `echo -ne "\x1EPoseidon %s $(date +%%s%%3N` + debugTimeDebugMessageFormat + `)\x1E"`
+	timeDebugMessageFormat = `echo -ne "\x1EPoseidon %s $(date +%%s%%3N)\x1E"`
 	// Format Parameters: 1. Debug Comment, 2. command.
 	timeDebugMessageFormatStart = timeDebugMessageFormat + `; %s`
 	// Format Parameters: 1. command, 2. Debug Comment.

--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -181,6 +181,14 @@ func (f File) ByteContent() []byte {
 	}
 }
 
+// Formatter mirrors the available Formatters of logrus for configuration purposes.
+type Formatter string
+
+const (
+	FormatterText = "TextFormatter"
+	FormatterJSON = "JSONFormatter"
+)
+
 // ContextKey is the type for keys in a request context that is used for passing data to the next handler.
 type ContextKey string
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/getsentry/sentry-go"
+	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/sirupsen/logrus"
 	"net"
 	"net/http"
@@ -12,10 +13,12 @@ import (
 	"time"
 )
 
+const TimestampFormat = "2006-01-02T15:04:05.000000Z"
+
 var log = &logrus.Logger{
 	Out: os.Stderr,
 	Formatter: &logrus.TextFormatter{
-		TimestampFormat: "2006-01-02T15:04:05.000000Z",
+		TimestampFormat: TimestampFormat,
 		DisableColors:   true,
 		FullTimestamp:   true,
 	},
@@ -25,13 +28,18 @@ var log = &logrus.Logger{
 
 const GracefulSentryShutdown = 5 * time.Second
 
-func InitializeLogging(loglevel string) {
-	level, err := logrus.ParseLevel(loglevel)
+func InitializeLogging(logLevel string, formatter dto.Formatter) {
+	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		log.WithError(err).Fatal("Error parsing loglevel")
 		return
 	}
 	log.SetLevel(level)
+	if formatter == dto.FormatterJSON {
+		log.Formatter = &logrus.JSONFormatter{
+			TimestampFormat: TimestampFormat,
+		}
+	}
 	log.AddHook(&SentryHook{})
 	log.ExitFunc = func(i int) {
 		sentry.Flush(GracefulSentryShutdown)
@@ -43,23 +51,23 @@ func GetLogger(pkg string) *logrus.Entry {
 	return log.WithField("package", pkg)
 }
 
-// loggingResponseWriter wraps the default http.ResponseWriter and catches the status code
+// ResponseWriter wraps the default http.ResponseWriter and catches the status code
 // that is written.
-type loggingResponseWriter struct {
+type ResponseWriter struct {
 	http.ResponseWriter
 	StatusCode int
 }
 
-func NewLoggingResponseWriter(w http.ResponseWriter) *loggingResponseWriter {
-	return &loggingResponseWriter{w, http.StatusOK}
+func NewLoggingResponseWriter(w http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{w, http.StatusOK}
 }
 
-func (writer *loggingResponseWriter) WriteHeader(code int) {
+func (writer *ResponseWriter) WriteHeader(code int) {
 	writer.StatusCode = code
 	writer.ResponseWriter.WriteHeader(code)
 }
 
-func (writer *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (writer *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	conn, rw, err := writer.ResponseWriter.(http.Hijacker).Hijack()
 	if err != nil {
 		return conn, nil, fmt.Errorf("hijacking connection failed: %w", err)

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func mockHTTPStatusHandler(status int) http.Handler {
 func TestHTTPMiddlewareWarnsWhenInternalServerError(t *testing.T) {
 	var hook *test.Hook
 	log, hook = test.NewNullLogger()
-	InitializeLogging(logrus.DebugLevel.String())
+	InitializeLogging(logrus.DebugLevel.String(), dto.FormatterText)
 
 	request, err := http.NewRequest(http.MethodGet, "/", http.NoBody)
 	if err != nil {
@@ -34,7 +35,7 @@ func TestHTTPMiddlewareWarnsWhenInternalServerError(t *testing.T) {
 func TestHTTPMiddlewareDebugsWhenStatusOK(t *testing.T) {
 	var hook *test.Hook
 	log, hook = test.NewNullLogger()
-	InitializeLogging(logrus.DebugLevel.String())
+	InitializeLogging(logrus.DebugLevel.String(), dto.FormatterText)
 
 	request, err := http.NewRequest(http.MethodGet, "/", http.NoBody)
 	if err != nil {


### PR DESCRIPTION
Closes #325 

In order to fix the incomplete debug message we aim to ignore output of the runner after we have sent the `SIGQUIT`.

We could do so by:
- moving the `SentryDebugWriter` away from the debug command creation (in `nomad.go`) to the event processing (in `nomad_runner.go`).
- Let the `SentryDebugWriter` probe if it can write to the `CodeOceanWriter` before it processes the data.
- Passing a second context from `nomad.go` to the `nomad_runner.go` that is done when no output should be transferred (before the execution should be aborted).

I liked the second option the most which is now implemented in this PR.
The regression test is in a separate commit as it took more changes than the actual fix.