### PR TITLE
Retry Environment Recovery

### DIFF
--- a/cmd/poseidon/main_test.go
+++ b/cmd/poseidon/main_test.go
@@ -13,27 +13,35 @@ import (
 )
 
 func TestAWSDisabledUsesNomadManager(t *testing.T) {
+	disableRecovery, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	runnerManager, environmentManager := createManagerHandler(createNomadManager, true,
-		runner.NewAbstractManager(), &environment.AbstractManager{})
+		runner.NewAbstractManager(), &environment.AbstractManager{}, disableRecovery)
 	awsRunnerManager, awsEnvironmentManager := createManagerHandler(createAWSManager, false,
-		runnerManager, environmentManager)
+		runnerManager, environmentManager, disableRecovery)
 	assert.Equal(t, runnerManager, awsRunnerManager)
 	assert.Equal(t, environmentManager, awsEnvironmentManager)
 }
 
 func TestAWSEnabledWrappesNomadManager(t *testing.T) {
+	disableRecovery, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	runnerManager, environmentManager := createManagerHandler(createNomadManager, true,
-		runner.NewAbstractManager(), &environment.AbstractManager{})
+		runner.NewAbstractManager(), &environment.AbstractManager{}, disableRecovery)
 	awsRunnerManager, awsEnvironmentManager := createManagerHandler(createAWSManager,
-		true, runnerManager, environmentManager)
+		true, runnerManager, environmentManager, disableRecovery)
 	assert.NotEqual(t, runnerManager, awsRunnerManager)
 	assert.NotEqual(t, environmentManager, awsEnvironmentManager)
 }
 
 func TestShutdownOnOSSignal_Profiling(t *testing.T) {
 	called := false
+	disableRecovery, cancel := context.WithCancel(context.Background())
+	cancel()
 
-	server := initServer()
+	server := initServer(disableRecovery)
 	go shutdownOnOSSignal(server, context.Background(), func() {
 		called = true
 	})

--- a/internal/environment/nomad_environment.go
+++ b/internal/environment/nomad_environment.go
@@ -245,7 +245,7 @@ func (n *NomadEnvironment) Sample() (runner.Runner, bool) {
 	r, ok := n.idleRunners.Sample()
 	if ok && n.idleRunners.Length() < n.PrewarmingPoolSize() {
 		go func() {
-			err := util.RetryExponential(time.Second, func() error {
+			err := util.RetryExponential(func() error {
 				return n.createRunner(false)
 			})
 			if err != nil {

--- a/internal/environment/nomad_environment.go
+++ b/internal/environment/nomad_environment.go
@@ -245,9 +245,7 @@ func (n *NomadEnvironment) Sample() (runner.Runner, bool) {
 	r, ok := n.idleRunners.Sample()
 	if ok && n.idleRunners.Length() < n.PrewarmingPoolSize() {
 		go func() {
-			err := util.RetryExponential(func() error {
-				return n.createRunner(false)
-			})
+			err := util.RetryExponentialContext(n.ctx, func() error { return n.createRunner(false) })
 			if err != nil {
 				log.WithError(err).WithField(dto.KeyEnvironmentID, n.ID().ToString()).
 					Error("Couldn't create new runner for claimed one")

--- a/internal/environment/nomad_environment_test.go
+++ b/internal/environment/nomad_environment_test.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"context"
 	"fmt"
 	nomadApi "github.com/hashicorp/nomad/api"
 	"github.com/openHPI/poseidon/internal/nomad"
@@ -18,7 +19,7 @@ import (
 func TestConfigureNetworkCreatesNewNetworkWhenNoNetworkExists(t *testing.T) {
 	_, job := helpers.CreateTemplateJob()
 	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
-	environment := &NomadEnvironment{nil, "", job, nil, nil, nil}
+	environment := &NomadEnvironment{nil, "", job, nil, context.Background(), nil}
 
 	if assert.Equal(t, 0, len(defaultTaskGroup.Networks)) {
 		environment.SetNetworkAccess(true, []uint16{})
@@ -30,7 +31,7 @@ func TestConfigureNetworkCreatesNewNetworkWhenNoNetworkExists(t *testing.T) {
 func TestConfigureNetworkDoesNotCreateNewNetworkWhenNetworkExists(t *testing.T) {
 	_, job := helpers.CreateTemplateJob()
 	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
-	environment := &NomadEnvironment{nil, "", job, nil, nil, nil}
+	environment := &NomadEnvironment{nil, "", job, nil, context.Background(), nil}
 
 	networkResource := &nomadApi.NetworkResource{Mode: "cni/secure-bridge"}
 	defaultTaskGroup.Networks = []*nomadApi.NetworkResource{networkResource}
@@ -59,7 +60,7 @@ func TestConfigureNetworkSetsCorrectValues(t *testing.T) {
 			_, testJob := helpers.CreateTemplateJob()
 			testTaskGroup := nomad.FindAndValidateDefaultTaskGroup(testJob)
 			testTask := nomad.FindAndValidateDefaultTask(testTaskGroup)
-			testEnvironment := &NomadEnvironment{nil, "", job, nil, nil, nil}
+			testEnvironment := &NomadEnvironment{nil, "", job, nil, context.Background(), nil}
 
 			testEnvironment.SetNetworkAccess(false, ports)
 			mode, ok := testTask.Config["network_mode"]
@@ -74,7 +75,7 @@ func TestConfigureNetworkSetsCorrectValues(t *testing.T) {
 			_, testJob := helpers.CreateTemplateJob()
 			testTaskGroup := nomad.FindAndValidateDefaultTaskGroup(testJob)
 			testTask := nomad.FindAndValidateDefaultTask(testTaskGroup)
-			testEnvironment := &NomadEnvironment{nil, "", testJob, nil, nil, nil}
+			testEnvironment := &NomadEnvironment{nil, "", testJob, nil, context.Background(), nil}
 
 			testEnvironment.SetNetworkAccess(true, ports)
 			require.Equal(t, 1, len(testTaskGroup.Networks))
@@ -133,7 +134,7 @@ func TestRegisterTemplateJobSucceedsWhenMonitoringEvaluationSucceeds(t *testing.
 	apiClientMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 
 	environment := &NomadEnvironment{apiClientMock, "", &nomadApi.Job{},
-		storage.NewLocalStorage[runner.Runner](), nil, nil}
+		storage.NewLocalStorage[runner.Runner](), context.Background(), nil}
 	environment.SetID(tests.DefaultEnvironmentIDAsInteger)
 	err := environment.Register()
 
@@ -150,7 +151,7 @@ func TestRegisterTemplateJobReturnsErrorWhenMonitoringEvaluationFails(t *testing
 	apiClientMock.On("DeleteJob", mock.AnythingOfType("string")).Return(nil)
 
 	environment := &NomadEnvironment{apiClientMock, "", &nomadApi.Job{},
-		storage.NewLocalStorage[runner.Runner](), nil, nil}
+		storage.NewLocalStorage[runner.Runner](), context.Background(), nil}
 	environment.SetID(tests.DefaultEnvironmentIDAsInteger)
 	err := environment.Register()
 
@@ -177,7 +178,7 @@ func TestTwoSampleAddExactlyTwoRunners(t *testing.T) {
 
 	_, job := helpers.CreateTemplateJob()
 	environment := &NomadEnvironment{apiMock, templateEnvironmentJobHCL, job,
-		storage.NewLocalStorage[runner.Runner](), nil, nil}
+		storage.NewLocalStorage[runner.Runner](), context.Background(), nil}
 	environment.SetPrewarmingPoolSize(2)
 	runner1 := &runner.RunnerMock{}
 	runner1.On("ID").Return(tests.DefaultRunnerID)
@@ -212,7 +213,7 @@ func TestSampleDoesNotSetForcePullFlag(t *testing.T) {
 
 	_, job := helpers.CreateTemplateJob()
 	environment := &NomadEnvironment{apiMock, templateEnvironmentJobHCL, job,
-		storage.NewLocalStorage[runner.Runner](), nil, nil}
+		storage.NewLocalStorage[runner.Runner](), context.Background(), nil}
 	runner1 := &runner.RunnerMock{}
 	runner1.On("ID").Return(tests.DefaultRunnerID)
 	environment.AddRunner(runner1)

--- a/internal/environment/nomad_manager.go
+++ b/internal/environment/nomad_manager.go
@@ -36,6 +36,7 @@ func NewNomadEnvironmentManager(
 	runnerManager runner.Manager,
 	apiClient nomad.ExecutorAPI,
 	templateJobFile string,
+	ctx context.Context,
 ) (*NomadEnvironmentManager, error) {
 	if err := loadTemplateEnvironmentJobHCL(templateJobFile); err != nil {
 		return nil, err
@@ -43,7 +44,7 @@ func NewNomadEnvironmentManager(
 
 	m := &NomadEnvironmentManager{&AbstractManager{nil, runnerManager},
 		apiClient, templateEnvironmentJobHCL}
-	if err := util.RetryExponential(func() error { return m.Load() }); err != nil {
+	if err := util.RetryExponentialContext(ctx, func() error { return m.Load() }); err != nil {
 		log.WithError(err).Error("Error recovering the execution environments")
 	}
 	runnerManager.Load()

--- a/internal/environment/nomad_manager.go
+++ b/internal/environment/nomad_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openHPI/poseidon/pkg/logging"
 	"github.com/openHPI/poseidon/pkg/monitoring"
 	"github.com/openHPI/poseidon/pkg/storage"
+	"github.com/openHPI/poseidon/pkg/util"
 	"os"
 	"time"
 )
@@ -42,7 +43,7 @@ func NewNomadEnvironmentManager(
 
 	m := &NomadEnvironmentManager{&AbstractManager{nil, runnerManager},
 		apiClient, templateEnvironmentJobHCL}
-	if err := m.Load(); err != nil {
+	if err := util.RetryExponential(func() error { return m.Load() }); err != nil {
 		log.WithError(err).Error("Error recovering the execution environments")
 	}
 	runnerManager.Load()

--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -55,7 +55,7 @@ func (m *NomadRunnerManager) Claim(environmentID dto.EnvironmentID, duration int
 }
 
 func (m *NomadRunnerManager) markRunnerAsUsed(runner Runner, timeoutDuration int) {
-	err := util.RetryExponential(time.Second, func() (err error) {
+	err := util.RetryExponential(func() (err error) {
 		if err = m.apiClient.MarkRunnerAsUsed(runner.ID(), timeoutDuration); err != nil {
 			err = fmt.Errorf("cannot mark runner as used: %w", err)
 		}

--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -129,7 +129,7 @@ func (m *NomadRunnerManager) keepRunnersSynced(ctx context.Context) {
 		err := m.apiClient.WatchEventStream(ctx,
 			&nomad.AllocationProcessing{OnNew: m.onAllocationAdded, OnDeleted: m.onAllocationStopped})
 		retries += 1
-		log.WithContext(ctx).WithError(err).Errorf("Stopped updating the runners! Retry %v", retries)
+		log.WithContext(ctx).WithError(err).WithField("count", retries).Errorf("Nomad Event Stream failed! Retrying...")
 		<-time.After(time.Second)
 	}
 }

--- a/internal/runner/nomad_runner.go
+++ b/internal/runner/nomad_runner.go
@@ -244,7 +244,7 @@ func (r *NomadJob) Destroy(reason DestroyReason) (err error) {
 	}
 
 	if err == nil && !errors.Is(reason, ErrOOMKilled) {
-		err = util.RetryExponential(time.Second, func() (err error) {
+		err = util.RetryExponential(func() (err error) {
 			if err = r.api.DeleteJob(r.ID()); err != nil {
 				err = fmt.Errorf("error deleting runner in Nomad: %w", err)
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,6 +9,8 @@ var (
 	log = logging.GetLogger("util")
 	// MaxConnectionRetriesExponential is the default number of retries. It's exported for testing reasons.
 	MaxConnectionRetriesExponential = 18
+	// InitialWaitingDuration is the default initial duration of waiting after a failed time.
+	InitialWaitingDuration = time.Second
 )
 
 // RetryExponentialAttempts executes the passed function
@@ -28,6 +30,10 @@ func RetryExponentialAttempts(attempts int, sleep time.Duration, f func() error)
 	return err
 }
 
-func RetryExponential(sleep time.Duration, f func() error) error {
+func RetryExponentialDuration(sleep time.Duration, f func() error) error {
 	return RetryExponentialAttempts(MaxConnectionRetriesExponential, sleep, f)
+}
+
+func RetryExponential(f func() error) error {
+	return RetryExponentialDuration(InitialWaitingDuration, f)
 }


### PR DESCRIPTION
Closes #408 

The retry is blocking as (1) we require a proper Nomad connection for Poseidon to work and (2) we would risk doubling the number of idle runner when an external request creates an environment before we have recovered it.