### PR TITLE
Fix Memory Leak caused by the merge_context.

### DIFF
--- a/pkg/util/merge_context.go
+++ b/pkg/util/merge_context.go
@@ -39,7 +39,6 @@ func (m mergeContext) Done() <-chan struct{} {
 	}
 	go func(cases []reflect.SelectCase, ch chan struct{}) {
 		_, _, _ = reflect.Select(cases)
-		ch <- struct{}{}
 		close(ch)
 	}(cases, ch)
 	return ch


### PR DESCRIPTION
Related to #429; Already deployed

The now removed statement of sending an empty struct into the channel blocked the goroutine until the channel of Done got listened for. This led to a goroutine leak as one does not necessarily has to call the Done function of a context.

We fix this issue by removing this value. It was unnecessary anyway as a closed channel always returns the null-value of the returned type.