### PR TITLE
Fix the recent event of lost runners

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -453,7 +453,8 @@ func handlePendingAllocationEvent(alloc *nomadApi.Allocation, allocData *allocat
 			stopExpected:       stopExpected,
 		})
 	case structs.AllocDesiredStatusStop:
-		handleStoppingAllocationEvent(alloc, allocations, callbacks, false)
+		// As this allocation was still pending, we don't have to propagate its deletion.
+		allocations.Delete(alloc.ID)
 		// Anyway, we want to monitor the occurrences.
 		if !allocData.stopExpected {
 			log.WithField("alloc", alloc).Warn("Pending allocation was stopped unexpectedly")

--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -390,10 +390,10 @@ func filterDuplicateEvents(alloc *nomadApi.Allocation, allocations storage.Stora
 		return true
 	case !ok:
 		// This case happens in case of an error or when an event that led to the deletion of the alloc data is duplicated.
-		log.WithField("alloc", alloc).Debug("Ignoring unknown allocation")
+		log.WithField("allocID", alloc.ID).Debug("Ignoring unknown allocation")
 		return false
 	case alloc.ClientStatus == allocData.allocClientStatus && alloc.DesiredStatus == allocData.allocDesiredStatus:
-		log.WithField("alloc", alloc).Debug("Ignoring duplicate event")
+		log.WithField("allocID", alloc.ID).Debug("Ignoring duplicate event")
 		return false
 	default:
 		return true

--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -578,26 +578,6 @@ func (s *MainTestSuite) TestHandleAllocationEventBuffersPendingAllocation() {
 	})
 }
 
-func (s *MainTestSuite) TestHandleAllocationEvent_IgnoresReschedulesForStoppedJobs() {
-	startedAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusRun)
-	rescheduledAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusRun)
-	rescheduledAllocation.ID = tests.AnotherUUID
-	rescheduledAllocation.PreviousAllocation = startedAllocation.ID
-	rescheduledEvent := eventForAllocation(s.T(), rescheduledAllocation)
-
-	allocations := storage.NewLocalStorage[*allocationData]()
-	allocations.Add(startedAllocation.ID, &allocationData{jobID: startedAllocation.JobID})
-
-	err := handleAllocationEvent(time.Now().UnixNano(), allocations, &rescheduledEvent, &AllocationProcessing{
-		OnNew:     func(_ *nomadApi.Allocation, _ time.Duration) {},
-		OnDeleted: func(_ string, _ error) bool { return true },
-	})
-	s.Require().NoError(err)
-
-	_, ok := allocations.Get(rescheduledAllocation.ID)
-	s.False(ok)
-}
-
 func (s *MainTestSuite) TestHandleAllocationEvent_RegressionTest_14_09_2023() {
 	jobID := "29-6f04b525-5315-11ee-af32-fa163e079f19"
 	a1ID := "04d86250-550c-62f9-9a21-ecdc3b38773e"

--- a/internal/nomad/nomad_test.go
+++ b/internal/nomad/nomad_test.go
@@ -518,9 +518,9 @@ func (s *MainTestSuite) TestApiClient_WatchAllocationsUsesCallbacksForEvents() {
 	stoppedPendingAllocation := createRecentAllocation(structs.AllocClientStatusPending, structs.AllocDesiredStatusStop)
 	stoppedPendingEvents := nomadApi.Events{Events: []nomadApi.Event{eventForAllocation(s.T(), stoppedPendingAllocation)}}
 
-	s.Run("it removes stopped pending allocations", func() {
+	s.Run("it does not callback for stopped pending allocations", func() {
 		assertWatchAllocation(s, []*nomadApi.Events{&pendingEvents, &stoppedPendingEvents},
-			[]*nomadApi.Allocation(nil), []string{stoppedPendingAllocation.JobID})
+			[]*nomadApi.Allocation(nil), []string(nil))
 	})
 
 	failedAllocation := createRecentAllocation(structs.AllocClientStatusFailed, structs.AllocDesiredStatusStop)


### PR DESCRIPTION
In the recent host migration, different Nomad hosts got restarted. This PR handles the case of runner `29-6f04b525-5315-11ee-af32-fa163e079f19`. What happens in its [Poseidon Log](https://github.com/openHPI/poseidon/files/12643314/poseidonLog.txt) is documented in the test case `TestHandleAllocationEvent_RegressionTest_14_09_2023`.

In summary, multiple consecutive reschedulings led again (such as in #433) to the wrong triggering of the race condition handling. As this handling (introduced in f031219cb8cd02f289abb4d107396fd7457a69f6) already caused multiple bugs and its purpose seems to be just to suppress incorrect warnings in case of a race condition, I replaced it with an implementation that does not influence the process.



