### PR TITLE
Fix WebSocket JSON schema

### DIFF
--- a/api/websocket.schema.json
+++ b/api/websocket.schema.json
@@ -6,38 +6,36 @@
     {
       "properties": {
         "type": {
-          "const": "exit",
-          "required": true
+          "const": "exit"
         },
         "data": {
           "type": "integer",
-          "required": true,
           "minimum": 0,
           "maximum": 255
         }
       },
+      "required": ["type", "data"],
       "additionalProperties": false
     },
     {
       "properties": {
         "type": {
-          "enum": [ "stdout", "stderr", "error" ],
-          "required": true
+          "enum": [ "stdout", "stderr", "error" ]
         },
         "data": {
-          "type": "string",
-          "required": true
+          "type": "string"
         }
       },
+      "required": ["type", "data"],
       "additionalProperties": false
     },
     {
       "properties": {
         "type": {
-          "enum": [ "start", "timeout" ],
-          "required": true
+          "enum": [ "start", "timeout" ]
         }
       },
+      "required": ["type"],
       "additionalProperties": false
     }
   ]


### PR DESCRIPTION
by changing the `required` attribute to be an array as described in [the official documentation](https://json-schema.org/understanding-json-schema/reference/object.html#required).