### PR TITLE
Fix flaky unit tests

### DIFF
--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -260,13 +260,10 @@ func (s *ManagerTestSuite) TestUpdateRunnersLogsErrorFromWatchAllocation() {
 		})
 	})
 
-	go func() {
-		err := s.nomadRunnerManager.SynchronizeRunners(s.TestCtx)
-		if err != nil {
-			log.WithError(err).Error("failed to synchronize runners")
-		}
-	}()
-	<-time.After(10 * time.Millisecond)
+	err := s.nomadRunnerManager.SynchronizeRunners(s.TestCtx)
+	if err != nil {
+		log.WithError(err).Error("failed to synchronize runners")
+	}
 
 	s.Require().Equal(3, len(hook.Entries))
 	s.Equal(logrus.ErrorLevel, hook.LastEntry().Level)

--- a/internal/runner/nomad_runner_test.go
+++ b/internal/runner/nomad_runner_test.go
@@ -221,7 +221,7 @@ func (s *ExecuteInteractivelyTestSuite) TestSendsSignalAfterTimeout() {
 		s.Require().True(ok)
 		buffer := make([]byte, 1) //nolint:makezero,lll // If the length is zero, the Read call never reads anything. gofmt want this alignment.
 		for n := 0; !(n == 1 && buffer[0] == SIGQUIT); {
-			time.After(tests.ShortTimeout)
+			<-time.After(tests.ShortTimeout)
 			n, _ = stdin.Read(buffer) //nolint:errcheck,lll // Read returns EOF errors but that is expected. This nolint makes the line too long.
 			if n > 0 {
 				log.WithField("buffer", fmt.Sprintf("%x", buffer[0])).Info("Received Stdin")

--- a/tests/util.go
+++ b/tests/util.go
@@ -39,6 +39,8 @@ type MemoryLeakTestSuite struct {
 }
 
 func (s *MemoryLeakTestSuite) SetupTest() {
+	// Without this first line we observed some goroutines just closing.
+	runtime.Gosched()
 	s.ExpectedGoroutingIncrease = 0
 	s.goroutinesBefore = &bytes.Buffer{}
 


### PR DESCRIPTION
Closes #494

- [x] TestWithSeparateStderr [[1]](https://github.com/openHPI/poseidon/actions/runs/6496629514/job/17644043545?pr=477) [[2]](https://github.com/openHPI/poseidon/actions/runs/6496654286/job/17644276544) [[3]](https://github.com/openHPI/poseidon/actions/runs/6767336052/job/18389825921)
- [x] TestGetNextRunnerTestSuite/TestUpdateRunnersLogsErrorFromWatchAllocation [[1]](https://github.com/openHPI/poseidon/actions/runs/6496629514/job/17644298555)
- [x] TestSendsSignalAfterTimeout 
- [x] TestGetNextRunnerTestSuite/TestUpdateRunnersAddsIdleRunner [[1]](https://github.com/openHPI/poseidon/actions/runs/6414410144/job/17414778349?pr=472) [[2]](https://github.com/openHPI/poseidon/actions/runs/6496629514/job/17644163370)
  - Flaky behavior could not be reproduced
- [x] TestUpdateFileSystemTestSuite/TestFileCopyIsCanceledOnRunnerDestroy [[1]](https://github.com/openHPI/poseidon/actions/runs/6414410144/job/17414778349?pr=472)
  - Flaky behavior could not be reproduced
- [x] TestDeleteRunnerRouteTestSuite/TestDeleteInvalidRunnerIdReturnsGone [[1]](https://github.com/openHPI/poseidon/actions/runs/6496654286/job/17644134178?pr=481)
  - Flaky behavior could not be reproduced
- [x] TestMainTestSuite/TestApiClient_init [[1]](https://github.com/openHPI/poseidon/actions/runs/6496654286/job/17644383975)
  - Flaky behavior could not be reproduced