### PR TITLE
Decrease Log Severity

### DIFF
--- a/internal/api/runners.go
+++ b/internal/api/runners.go
@@ -226,7 +226,7 @@ func (r *RunnerController) findRunnerMiddleware(next http.Handler) http.Handler 
 			// See https://github.com/openHPI/poseidon/issues/54
 			_, readErr := io.ReadAll(request.Body)
 			if readErr != nil {
-				log.WithContext(request.Context()).WithError(readErr).Warn("Failed to discard the request body")
+				log.WithContext(request.Context()).WithError(readErr).Debug("Failed to discard the request body")
 			}
 			writeClientError(writer, err, http.StatusGone, request.Context())
 			return

--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -134,12 +134,14 @@ func addEnvironmentID(r *http.Request, id dto.EnvironmentID) {
 func AddRequestSize(r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.WithContext(r.Context()).WithError(err).Warn("Failed to read request body")
+		log.WithContext(r.Context()).WithError(err).Debug("Failed to read request body")
+		return
 	}
 
 	err = r.Body.Close()
 	if err != nil {
-		log.WithContext(r.Context()).WithError(err).Warn("Failed to close request body")
+		log.WithContext(r.Context()).WithError(err).Debug("Failed to close request body")
+		return
 	}
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
 


### PR DESCRIPTION
of errors trying to read the request body.

This is okay, as those errors indicate an issue with the client (CodeOcean) or the network, and we do not like to track those issues in the context of Poseidon.

Closes #467 

