### PR TITLE
Remove deprecated `syscall` dependency.

### DIFF
--- a/cmd/poseidon/main.go
+++ b/cmd/poseidon/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/pkg/logging"
 	"github.com/openHPI/poseidon/pkg/monitoring"
+	"golang.org/x/sys/unix"
 	"net/http"
 	"os"
 	"os/signal"
@@ -19,7 +20,6 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"strconv"
-	"syscall"
 	"time"
 )
 
@@ -243,11 +243,11 @@ func initServer(ctx context.Context) *http.Server {
 func shutdownOnOSSignal(server *http.Server, ctx context.Context, stopProfiling func()) {
 	// wait for SIGINT
 	shutdownSignals := make(chan os.Signal, 1)
-	signal.Notify(shutdownSignals, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(shutdownSignals, unix.SIGINT, unix.SIGTERM)
 
 	// wait for SIGUSR1
 	writeProfileSignal := make(chan os.Signal, 1)
-	signal.Notify(writeProfileSignal, syscall.SIGUSR1)
+	signal.Notify(writeProfileSignal, unix.SIGUSR1)
 
 	select {
 	case <-ctx.Done():

--- a/cmd/poseidon/main_test.go
+++ b/cmd/poseidon/main_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/tests"
 	"github.com/stretchr/testify/suite"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 )
@@ -57,7 +57,7 @@ func (s *MainTestSuite) TestShutdownOnOSSignal_Profiling() {
 	})
 
 	<-time.After(tests.ShortTimeout)
-	err := syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	err := unix.Kill(unix.Getpid(), unix.SIGUSR1)
 	s.Require().NoError(err)
 	<-time.After(tests.ShortTimeout)
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/sys v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -143,7 +144,6 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect


### PR DESCRIPTION
Closes #505 