### PR TITLE
Inject Execution Debug Message

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -696,6 +696,7 @@ func prepareCommandTTY(command string, currentNanoTime int64, privilegedExecutio
 	// Take the command to be executed and wrap it to redirect stderr.
 	stderrFifoPath := stderrFifo(currentNanoTime)
 	command = fmt.Sprintf(stderrWrapperCommandFormat, stderrFifoPath, command, stderrFifoPath)
+	command = injectStartDebugMessage(command, 0, 1)
 
 	command = setUserCommand(command, privilegedExecution)
 	command = unsetEnvironmentVariables(command)


### PR DESCRIPTION
for measuring the performance of the until loop of the stderr connection.

Closes #442

Accidentally, I pushed this commit directly to `main`.  
In response, I reverted that commit on `main` and enabled the branch protection rule `Do not allow bypassing the above settings`.