### PR TITLE
Decrease Log severity

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -93,11 +93,7 @@ func HTTPLoggingMiddleware(next http.Handler) http.Handler {
 			"duration":   latency,
 			"user_agent": RemoveNewlineSymbol(r.UserAgent()),
 		})
-		if lrw.StatusCode >= http.StatusInternalServerError {
-			logEntry.Error("Failing " + path)
-		} else {
-			logEntry.Debug()
-		}
+		logEntry.Debug()
 	})
 }
 

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -25,22 +25,6 @@ func TestMainTestSuite(t *testing.T) {
 	suite.Run(t, new(MainTestSuite))
 }
 
-func (s *MainTestSuite) TestHTTPMiddlewareWarnsWhenInternalServerError() {
-	var hook *test.Hook
-	log, hook = test.NewNullLogger()
-	InitializeLogging(logrus.DebugLevel.String(), dto.FormatterText)
-
-	request, err := http.NewRequest(http.MethodGet, "/", http.NoBody)
-	if err != nil {
-		s.Fail(err.Error())
-	}
-	recorder := httptest.NewRecorder()
-	HTTPLoggingMiddleware(mockHTTPStatusHandler(500)).ServeHTTP(recorder, request)
-
-	s.Equal(1, len(hook.Entries))
-	s.Equal(logrus.ErrorLevel, hook.LastEntry().Level)
-}
-
 func (s *MainTestSuite) TestHTTPMiddlewareDebugsWhenStatusOK() {
 	var hook *test.Hook
 	log, hook = test.NewNullLogger()


### PR DESCRIPTION
of failing requests because it's likely that another error with more information has already been reported.

Closes #420 