### PR TITLE
Decouple InfluxDB writings from request handling.

### DIFF
--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -164,7 +164,8 @@ func ChangedPrewarmingPoolSize(id dto.EnvironmentID, count uint) {
 func WriteInfluxPoint(p *write.Point) {
 	if influxClient != nil {
 		p.AddTag("stage", config.Config.InfluxDB.Stage)
-		influxClient.WritePoint(p)
+		// We identified that the influxClient is not truly asynchronous. See #541.
+		go func() { influxClient.WritePoint(p) }()
 	} else {
 		entry := log.WithField("name", p.Name())
 		for _, tag := range p.TagList() {


### PR DESCRIPTION
With #451, we found that writing an InfluxDB data point might block and lead to high latencies.

Implements "Issue" 1 of https://github.com/openHPI/poseidon/issues/541#issuecomment-1912579294