### PR TITLE
Fix linter emptyStringTest rule

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -77,7 +77,7 @@ func configureV1Router(router *mux.Router,
 // It responds the release information stored in the configuration.
 func Version(writer http.ResponseWriter, request *http.Request) {
 	release := config.Config.Sentry.Release
-	if len(release) > 0 {
+	if release != "" {
 		sendJSON(writer, release, http.StatusOK, request.Context())
 	} else {
 		writer.WriteHeader(http.StatusNotFound)

--- a/internal/api/environments.go
+++ b/internal/api/environments.go
@@ -149,7 +149,7 @@ func parseEnvironmentID(request *http.Request) (dto.EnvironmentID, error) {
 
 func parseFetchParameter(request *http.Request) (fetch bool, err error) {
 	fetchString := request.FormValue(fetchEnvironmentKey)
-	if len(fetchString) > 0 {
+	if fetchString != "" {
 		fetch, err = strconv.ParseBool(fetchString)
 		if err != nil {
 			return false, fmt.Errorf("could not parse fetch parameter: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,7 +273,7 @@ func loadValue(prefix string, value reflect.Value, logEntry *logrus.Entry) {
 		}
 		value.SetBool(boolean)
 	case reflect.Slice:
-		if len(content) > 0 && content[0] == '"' && content[len(content)-1] == '"' {
+		if content != "" && content[0] == '"' && content[len(content)-1] == '"' {
 			content = content[1 : len(content)-1] // remove wrapping quotes
 		}
 		parts := strings.Fields(content)


### PR DESCRIPTION
by replacing the length check with a string comparison. This rule was introduced with the new GolangCI lint version.