### PR TITLE
Fix Runner DNS resolution

### DIFF
--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -65,6 +65,14 @@ nomad:
   # namespace: poseidon
   # Prefer local Docker images over pulling them from a registry. Images with the `latest` tag will always be force pulled by Nomad regardless of this configuration.
   disableforcepull: true
+  # Network configuration for network-enabled runners. See https://developer.hashicorp.com/nomad/docs/job-specification/network.
+  network:
+    # Available Modes: "none", "bridge", "host", "cni/*".
+    # "none": Even the network-enabled runners will be isolated.
+    # "bridge": Isolated network namespace with bridged interface. Linux-only.
+    # "host": Using the host network namespace. Less-secure.
+    # "cni/*": Configure an isolated network namespace using CNI. For example, this can be a more secured bridge network.
+    mode: "cni/secure-bridge"
 
 aws:
   # Specifies whether AWS should be used as executor.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/getsentry/sentry-go"
+	nomadApi "github.com/hashicorp/nomad/api"
 	"github.com/openHPI/poseidon/pkg/dto"
 	"github.com/openHPI/poseidon/pkg/logging"
 	"github.com/sirupsen/logrus"
@@ -54,6 +55,10 @@ var (
 			},
 			Namespace:        "default",
 			DisableForcePull: false,
+			Network: nomadApi.NetworkResource{
+				Mode: "bridge",
+				DNS:  nil,
+			},
 		},
 		AWS: AWS{
 			Enabled:   false,
@@ -120,6 +125,7 @@ type Nomad struct {
 	TLS              TLS
 	Namespace        string
 	DisableForcePull bool
+	Network          nomadApi.NetworkResource
 }
 
 // URL returns the URL for the configured Nomad cluster.

--- a/internal/environment/nomad_environment_test.go
+++ b/internal/environment/nomad_environment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	nomadApi "github.com/hashicorp/nomad/api"
+	"github.com/openHPI/poseidon/internal/config"
 	"github.com/openHPI/poseidon/internal/nomad"
 	"github.com/openHPI/poseidon/internal/runner"
 	"github.com/openHPI/poseidon/pkg/storage"
@@ -32,14 +33,14 @@ func (s *MainTestSuite) TestConfigureNetworkDoesNotCreateNewNetworkWhenNetworkEx
 	defaultTaskGroup := nomad.FindAndValidateDefaultTaskGroup(job)
 	environment := &NomadEnvironment{nil, "", job, nil, context.Background(), nil}
 
-	networkResource := &nomadApi.NetworkResource{Mode: "cni/secure-bridge"}
-	defaultTaskGroup.Networks = []*nomadApi.NetworkResource{networkResource}
+	networkResource := config.Config.Nomad.Network
+	defaultTaskGroup.Networks = []*nomadApi.NetworkResource{&networkResource}
 
 	if s.Equal(1, len(defaultTaskGroup.Networks)) {
 		environment.SetNetworkAccess(true, []uint16{})
 
 		s.Equal(1, len(defaultTaskGroup.Networks))
-		s.Equal(networkResource, defaultTaskGroup.Networks[0])
+		s.Equal(&networkResource, defaultTaskGroup.Networks[0])
 	}
 }
 
@@ -80,7 +81,7 @@ func (s *MainTestSuite) TestConfigureNetworkSetsCorrectValues() {
 			s.Require().Equal(1, len(testTaskGroup.Networks))
 
 			networkResource := testTaskGroup.Networks[0]
-			s.Equal("cni/secure-bridge", networkResource.Mode)
+			s.Equal(config.Config.Nomad.Network.Mode, networkResource.Mode)
 			s.Require().Equal(len(ports), len(networkResource.DynamicPorts))
 
 			assertExpectedPorts(s.T(), ports, networkResource)


### PR DESCRIPTION
Closes #490 

The failing DNS resolution was caused by Nomad overwriting the DNS configuration of Docker and the CNI secure bridge. To set valid Nameservers, we have to configure the according Nomad options.