### PR TITLE
Fix Golangci-lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+run:
+  go: "1.22"
+
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -7,8 +10,6 @@ linters-settings:
     statements: 50
   gocognit:
     min-complexity: 15
-  goconst:
-    min-occurences: 2
   gocritic:
     enabled-tags:
       - diagnostic
@@ -25,35 +26,26 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   gomnd:
-    settings:
-      mnd:
-        # don't include "assign"
-        checks:
-        - argument
-        - case
-        - condition
-        - operation
-        - return
-  importas:
-    unaliased: false
+    # don't include "assign"
+    checks:
+    - argument
+    - case
+    - condition
+    - operation
+    - return
   lll:
     line-length: 150
   makezero:
     always: true
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
   nakedret:
     max-func-lines: 5
-  stylecheck:
-    go: "1.22"
 
 linters:
   disable-all: true
   enable:
     # default
-    - deadcode
     - errcheck
     - gosimple
     - govet
@@ -61,7 +53,6 @@ linters:
     - staticcheck
     - typecheck
     - unused
-    - varcheck
     # additional linters, see https://golangci-lint.run/usage/linters
     - bodyclose
     - dogsled
@@ -75,9 +66,9 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - goerr113
+    - err113
     - gofmt
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - importas

--- a/cmd/poseidon/main.go
+++ b/cmd/poseidon/main.go
@@ -393,15 +393,17 @@ func initRouter(ctx context.Context) *mux.Router {
 // initServer creates a server that serves the routes provided by the router.
 func initServer(router *mux.Router) *http.Server {
 	sentryHandler := sentryhttp.New(sentryhttp.Options{}).Handle(router)
+	const readTimeout = 15 * time.Second
+	const idleTimeout = 60 * time.Second
 
 	return &http.Server{
 		Addr: config.Config.Server.URL().Host,
 		// A WriteTimeout would prohibit long-running requests such as creating an execution environment.
 		// See also https://github.com/openHPI/poseidon/pull/68.
 		// WriteTimeout: time.Second * 15,
-		ReadHeaderTimeout: time.Second * 15,
-		ReadTimeout:       time.Second * 15,
-		IdleTimeout:       time.Second * 60,
+		ReadHeaderTimeout: readTimeout,
+		ReadTimeout:       readTimeout,
+		IdleTimeout:       idleTimeout,
 		Handler:           sentryHandler,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,12 +20,18 @@ import (
 	"strings"
 )
 
+const (
+	defaultPoseidonPort              = 7200
+	defaultNomadPort                 = 4646
+	defaultMemoryUsageAlertThreshold = 1_000
+)
+
 // Config contains the default configuration of Poseidon.
 var (
 	Config = &configuration{
 		Server: server{
 			Address:                 "127.0.0.1",
-			Port:                    7200,
+			Port:                    defaultPoseidonPort,
 			SystemdSocketActivation: false,
 			Token:                   "",
 			TLS: TLS{
@@ -45,7 +51,7 @@ var (
 		Nomad: Nomad{
 			Enabled: true,
 			Address: "127.0.0.1",
-			Port:    4646,
+			Port:    defaultNomadPort,
 			Token:   "",
 			TLS: TLS{
 				Active:   false,
@@ -70,7 +76,7 @@ var (
 			Formatter: dto.FormatterText,
 		},
 		Profiling: Profiling{
-			MemoryThreshold: 1_000,
+			MemoryThreshold: defaultMemoryUsageAlertThreshold,
 		},
 		Sentry: sentry.ClientOptions{
 			AttachStacktrace: true,

--- a/internal/runner/nomad_runner.go
+++ b/internal/runner/nomad_runner.go
@@ -435,17 +435,21 @@ func fileDeletionCommand(pathsToDelete []dto.FilePath) string {
 }
 
 func tarHeader(file dto.File) *tar.Header {
+	// See #236. Sticky bit is to allow creating files next to write-protected files.
+	const directoryPermission int64 = 0o1777
+	const filePermission int64 = 0o744
+
 	if file.IsDirectory() {
 		return &tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     file.CleanedPath(),
-			Mode:     0o1777, // See #236. Sticky bit is to allow creating files next to write-protected files.
+			Mode:     directoryPermission,
 		}
 	} else {
 		return &tar.Header{
 			Typeflag: tar.TypeReg,
 			Name:     file.CleanedPath(),
-			Mode:     0o744,
+			Mode:     filePermission,
 			Size:     int64(len(file.Content)),
 		}
 	}

--- a/tests/constants.go
+++ b/tests/constants.go
@@ -27,12 +27,15 @@ const (
 	DefaultMockID                 = "m0ck-1d"
 	ShortTimeout                  = 100 * time.Millisecond
 	DefaultTestTimeout            = 10 * time.Minute
+
+	defaultPort = 42
+	anotherPort = 1337
 )
 
 var (
 	ErrDefault              = errors.New("an error occurred")
 	ErrCleanupDestroyReason = errors.New("destruction required for cleanup")
 
-	DefaultPortMappings = []nomadApi.PortMapping{{To: 42, Value: 1337, Label: "lit", HostIP: "127.0.0.1"}}
-	DefaultMappedPorts  = []*dto.MappedPort{{ExposedPort: 42, HostAddress: "127.0.0.1:1337"}}
+	DefaultPortMappings = []nomadApi.PortMapping{{To: defaultPort, Value: anotherPort, Label: "lit", HostIP: "127.0.0.1"}}
+	DefaultMappedPorts  = []*dto.MappedPort{{ExposedPort: defaultPort, HostAddress: "127.0.0.1:1337"}}
 )

--- a/tests/e2e/e2e_helpers.go
+++ b/tests/e2e/e2e_helpers.go
@@ -16,10 +16,13 @@ var log = logging.GetLogger("e2e-helpers")
 
 func CreateDefaultEnvironment(prewarmingPoolSize uint, image string) dto.ExecutionEnvironmentRequest {
 	path := helpers.BuildURL(api.BasePath, api.EnvironmentsPath, tests.DefaultEnvironmentIDAsString)
+	const smallCPULimit uint = 20
+	const smallMemoryLimit uint = 100
+
 	defaultNomadEnvironment := dto.ExecutionEnvironmentRequest{
 		PrewarmingPoolSize: prewarmingPoolSize,
-		CPULimit:           20,
-		MemoryLimit:        100,
+		CPULimit:           smallCPULimit,
+		MemoryLimit:        smallMemoryLimit,
 		Image:              image,
 		NetworkAccess:      false,
 		ExposedPorts:       nil,


### PR DESCRIPTION
Open to discussion: By specifying the linters explicitly in an allow list, we are missing all the linters that are added in each release. Should we drop the allow list and introduce a deny list if necessary?