### PR TITLE
Nomad Restart and Reschedule Policy

### DIFF
--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -11,11 +11,6 @@ job "template-0" {
       sticky  = false
     }
     count = 1
-    scaling {
-      enabled = true
-      min = 0
-      max = 300
-    }
     spread {
       // see https://www.nomadproject.io/docs/job-specification/spread#even-spread-across-data-center
       // This spreads the load evenly amongst our nodes

--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -18,11 +18,18 @@ job "template-0" {
       weight = 100
     }
     restart {
-      delay = "0s"
+      attempts = 3
+      delay = "15s"
+      interval = "1h"
+      mode = "fail"
     }
     reschedule {
-      unlimited = true
-      attempts = 0
+      unlimited = false
+      attempts = 3
+      interval = "6h"
+      delay = "1m"
+      max_delay = "4m"
+      delay_function = "exponential"
     }
 
     task "default-task" {


### PR DESCRIPTION
Related to #587 

Fix restart and reschedule configuration to not reschedule infinitely (e.g. due to an invalid image specifier).

ToDo:
- [ ] ~~Should we write an e2e test checking that a wrong environment definition does not loop infinitely? With the current configuration, the test will last almost 10 minutes..~~ No