### PR TITLE
Group Sentry issues

### DIFF
--- a/internal/api/runners.go
+++ b/internal/api/runners.go
@@ -147,9 +147,6 @@ func (r *RunnerController) updateFileSystem(writer http.ResponseWriter, request 
 	case errors.Is(err, nomadApi.NodeDownErr):
 		entry.Debug("Nomad Node Down while updateFileSystem")
 		writeInternalServerError(request.Context(), writer, err, dto.ErrorNomadInternalServerError)
-	case errors.Is(err, io.ErrUnexpectedEOF):
-		entry.Warn("Unexpected EOF while updateFileSystem")
-		writeInternalServerError(request.Context(), writer, err, dto.ErrorUnknown)
 	case errors.Is(err, nomad.ErrNoAllocationFound):
 		entry.Warn("No allocation found while updateFileSystem")
 		writeInternalServerError(request.Context(), writer, err, dto.ErrorUnknown)

--- a/internal/nomad/api_querier.go
+++ b/internal/nomad/api_querier.go
@@ -138,6 +138,9 @@ func (nc *nomadAPIClient) Execute(ctx context.Context, runnerID string, cmd stri
 	case errors.Is(err, context.Canceled):
 		log.WithContext(ctx).Debug("Execution canceled by context")
 		return 0, nil
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		log.WithContext(ctx).WithError(err).Warn("Unexpected EOF for Execute")
+		return 0, nil
 	case strings.Contains(err.Error(), "Unknown allocation"):
 		return 1, ErrNomadUnknownAllocation
 	default:


### PR DESCRIPTION
by throwing the log warning at the common level of the Execute call and not at multiple places relying on it.

Related to #589 