### PR TITLE
Fix Sentry Hook Global Scope

### DIFF
--- a/pkg/logging/context_hook.go
+++ b/pkg/logging/context_hook.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ContextHook logs the values referenced by the of dto.LoggedContextKeys.
-// By default Logrus does not log the values stored in the passed context.
+// By default, Logrus does not log the values stored in the passed context.
 type ContextHook struct{}
 
 // Fire is triggered on new log entries.


### PR DESCRIPTION
that led to errors being duplicated in the following events sharing the same scope.

Now, every event has its own local scope.

Closes #628