### PR TITLE
Fix Content Length Writer

### DIFF
--- a/internal/api/runners.go
+++ b/internal/api/runners.go
@@ -172,9 +172,12 @@ func (r *RunnerController) fileContent(writer http.ResponseWriter, request *http
 		err = targetRunner.GetFileContent(ctx, path, writer, privilegedExecution)
 	})
 	if errors.Is(err, runner.ErrFileNotFound) {
+		writer.Header().Del("Content-Length")
 		writeClientError(request.Context(), writer, err, http.StatusFailedDependency)
 		return
 	} else if err != nil {
+		// Otherwise, might assume that GetFileContent already wrote something and, therefore, the HTTP headers
+		// cannot be modified anymore.
 		log.WithContext(request.Context()).WithError(err).Error("Could not retrieve the requested file.")
 		writeInternalServerError(request.Context(), writer, err, dto.ErrorUnknown)
 		return

--- a/pkg/nullio/content_length.go
+++ b/pkg/nullio/content_length.go
@@ -31,6 +31,9 @@ func (w *ContentLengthWriter) Write(p []byte) (count int, err error) {
 }
 
 func (w *ContentLengthWriter) handleDataForwarding(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	count, err := w.Target.Write(p)
 	if err != nil {
 		err = fmt.Errorf("could not write to target: %w", err)


### PR DESCRIPTION
- The `Content-Length`-Header did not get removed in the error handling
- The Content-Length Writer fired the HTTP Headers unnecessarily early impeding sending of an error message.

Closes #595