### PR TITLE
Enable Dependabot for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,14 @@ updates:
     labels:
       - dependencies
       - github-actions
+
+  - package-ecosystem: docker
+    directories:
+      - "**/*"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - docker


### PR DESCRIPTION
Within this repo, we also have a few Dockerfiles that could deserve updates.