### PR TITLE
Separate Sentry Issues

### DIFF
--- a/internal/api/ws/codeocean_writer.go
+++ b/internal/api/ws/codeocean_writer.go
@@ -114,6 +114,10 @@ func (cw *codeOceanOutputWriter) Close(info *runner.ExitInfo) {
 		message := "the allocation stopped as expected"
 		log.WithContext(cw.ctx).WithError(info.Err).Trace(message)
 		cw.send(&dto.WebSocketMessage{Type: dto.WebSocketOutputError, Data: message})
+	case errors.Is(info.Err, runner.ErrDestroyedAndReplaced):
+		errorMessage := "Runner recovery stopped request execution"
+		log.WithContext(cw.ctx).WithError(info.Err).Warn(errorMessage)
+		cw.send(&dto.WebSocketMessage{Type: dto.WebSocketOutputError, Data: errorMessage})
 	default:
 		errorMessage := "Error executing the request"
 		log.WithContext(cw.ctx).WithError(info.Err).Warn(errorMessage)

--- a/internal/api/ws/codeocean_writer.go
+++ b/internal/api/ws/codeocean_writer.go
@@ -115,7 +115,7 @@ func (cw *codeOceanOutputWriter) Close(info *runner.ExitInfo) {
 		log.WithContext(cw.ctx).WithError(info.Err).Trace(message)
 		cw.send(&dto.WebSocketMessage{Type: dto.WebSocketOutputError, Data: message})
 	case errors.Is(info.Err, runner.ErrDestroyedAndReplaced):
-		errorMessage := "Runner recovery stopped request execution"
+		errorMessage := "Runner recovery stopped requested execution"
 		log.WithContext(cw.ctx).WithError(info.Err).Warn(errorMessage)
 		cw.send(&dto.WebSocketMessage{Type: dto.WebSocketOutputError, Data: errorMessage})
 	default:

--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -21,7 +21,7 @@ type EnvironmentAccessor interface {
 	// StoreEnvironment stores the environment in Poseidons memory.
 	StoreEnvironment(environment ExecutionEnvironment)
 
-	// DeleteEnvironment removes the specified execution environment in Poseidons memory.
+	// DeleteEnvironment removes the specified execution environment in Poseidon's memory.
 	// It does nothing if the specified environment can not be found.
 	DeleteEnvironment(id dto.EnvironmentID)
 


### PR DESCRIPTION
to allow for the differentiation of local recovery errors from generic execution failures.

Related to #651 

- We might want to decrease the Sentry Log Level for this issue.