### PR TITLE
Fix flaky inactivity timer test

### DIFF
--- a/internal/runner/inactivity_timer_test.go
+++ b/internal/runner/inactivity_timer_test.go
@@ -79,7 +79,7 @@ func (s *InactivityTimerTestSuite) TestTimeoutPassedReturnsTrueAfterDeadline() {
 func (s *InactivityTimerTestSuite) TestTimerIsNotResetAfterDeadline() {
 	time.Sleep(2 * tests.ShortTimeout)
 	// We need to empty the returned channel so Return can send to it again.
-	tests.ChannelReceivesSomething(s.returned, 0)
+	tests.ChannelReceivesSomething(s.returned, tests.ShortTimeout)
 	s.runner.ResetTimeout()
 	s.False(tests.ChannelReceivesSomething(s.returned, 2*tests.ShortTimeout))
 }

--- a/tests/util.go
+++ b/tests/util.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ChannelReceivesSomething waits timeout seconds for something to be received from channel ch.
-// If something is received, it returns true. If the timeout expires without receiving anything, it return false.
+// If something is received, it returns true. If the timeout expires without receiving anything, it returns false.
 func ChannelReceivesSomething(ch chan bool, timeout time.Duration) bool {
 	select {
 	case <-ch:


### PR DESCRIPTION
Closes #669 

There was a race condition between both channels in `ChannelReceivesSomething` having data.
The reason why this race condition appears only now is likely that the small delay of `<-time.After(0)` got reduced with [the timer refactoring of Go 1.23](https://go.dev/doc/go1.23#timer-changes).