### PR TITLE
Fix prohibiting Nomad Job recreation with delay in between

### DIFF
--- a/internal/nomad/nomad.go
+++ b/internal/nomad/nomad.go
@@ -33,7 +33,8 @@ var (
 		"%w correctly but rescheduled", ErrAllocationStopped)
 	// ErrAllocationCompleted is for reporting the reason for the stopped allocation.
 	// We do not consider it as an error but add it anyway for a complete reporting.
-	ErrAllocationCompleted RunnerDeletedReason = errors.New("the allocation completed")
+	// It is a ErrLocalDestruction because another allocation might be replacing the allocation in the same job.
+	ErrAllocationCompleted RunnerDeletedReason = fmt.Errorf("the allocation completed: %w", ErrLocalDestruction)
 )
 
 type RunnerDeletedReason error


### PR DESCRIPTION
by not purging a job once its allocation stops (and maybe would be replaced).

Related to #673 

Scenario: Deleting and Creating the environment before each restart
Before PR
1 - 0/5
2 - 0/5
3 - 0/5
4 - 0/5
5 - 0/5

After PR
1 - 5/5
2 - 5/5
3 - 5/5 (one slow recreation)
4 - 5/5
5 - 5/5