### PR TITLE
Fix OOM Killing Nomad Agent

### DIFF
--- a/internal/environment/template-environment-job.hcl
+++ b/internal/environment/template-environment-job.hcl
@@ -51,7 +51,7 @@ job "template-0" {
 
       resources {
         cpu    = 40
-        memory = 30
+        memory = 50
       }
     }
   }


### PR DESCRIPTION
by increasing the memory reservation per runner.

Closes #676 

This may not be the most stable solution as different environments (images) might require different amounts of memory. However, with increasing the memory reservation per runner only as many runners are allocated on the agent as it could handle right now (with the given server resources, and the allocation definition).