### PR TITLE
Add Nomad Job Event Handling

### DIFF
--- a/pkg/monitoring/influxdb2_middleware.go
+++ b/pkg/monitoring/influxdb2_middleware.go
@@ -25,6 +25,7 @@ const (
 	measurementPrefix           = "poseidon_"
 	measurementPoolSize         = measurementPrefix + "poolsize"
 	MeasurementNomadEvents      = measurementPrefix + "nomad_events"
+	MeasurementNomadJobs        = measurementPrefix + "nomad_jobs"
 	MeasurementNomadAllocations = measurementPrefix + "nomad_allocations"
 	MeasurementIdleRunnerNomad  = measurementPrefix + "nomad_idle_runners"
 	MeasurementExecutionsAWS    = measurementPrefix + "aws_executions"
@@ -38,6 +39,7 @@ const (
 	InfluxKeyRunnerID                      = dto.KeyRunnerID
 	InfluxKeyEnvironmentID                 = dto.KeyEnvironmentID
 	InfluxKeyJobID                         = "job_id"
+	InfluxKeyAllocationID                  = "allocation_id"
 	InfluxKeyClientStatus                  = "client_status"
 	InfluxKeyNomadNode                     = "nomad_agent"
 	InfluxKeyActualContentLength           = "actual_length"


### PR DESCRIPTION
for more reliant event handling.
In recent cases, we have observed Nomad not sending Allocation-stopping events but just JobDeregistered events. We add a handling of those to capture also these cases.

Closes #649 