### PR TITLE
Restrict false positive warning

### DIFF
--- a/internal/runner/nomad_manager.go
+++ b/internal/runner/nomad_manager.go
@@ -335,7 +335,7 @@ func monitorAllocationStartupDuration(startup time.Duration, runnerID string, en
 
 // checkForMigratingEnvironmentJob checks if the Nomad environment job is still running after the delay.
 func (m *NomadRunnerManager) checkForMigratingEnvironmentJob(ctx context.Context, jobID string, delay time.Duration) {
-	log.WithField(dto.KeyEnvironmentID, jobID).Debug("Environment stopped unexpectedly. Checking again..")
+	log.WithField(dto.KeyEnvironmentID, jobID).Debug("Environment stopped unexpectedly. Checking again...")
 
 	select {
 	case <-ctx.Done():

--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -510,16 +510,6 @@ func (s *ManagerTestSuite) TestOnAllocationStopped() {
 			s.True(alreadyRemoved)
 		})
 	})
-	s.Run("logs unexpectedly stopped environments", func() {
-		logger, hook := test.NewNullLogger()
-		log = logger.WithField("package", "runner")
-
-		alreadyRemoved := s.nomadRunnerManager.onAllocationStopped(s.TestCtx, tests.DefaultTemplateJobID, nil)
-		s.False(alreadyRemoved)
-
-		s.Len(hook.Entries, 1)
-		s.Equal(logrus.WarnLevel, hook.LastEntry().Level)
-	})
 	s.Run("does not log expectedly stopped environments", func() {
 		logger, hook := test.NewNullLogger()
 		log = logger.WithField("package", "runner")


### PR DESCRIPTION
"Environment stopped unexpectedly," which also got triggered by migrations.

Related to #672