### PR TITLE
AWS: Fix SimpleMakefile when command is wrapped

### DIFF
--- a/deploy/aws/java11Exec/src/main/java/poseidon/SimpleMakefile.java
+++ b/deploy/aws/java11Exec/src/main/java/poseidon/SimpleMakefile.java
@@ -22,7 +22,7 @@ class InvalidMakefileException extends Exception {}
 class SimpleMakefile {
 
     // This pattern validates if a command is a make command.
-    private static final Pattern isMakeCommand = Pattern.compile("^(?<before>.* && )?make(?:\\s+(?<startRule>\\w*))?(?<assignments>(?:.*?=.*?)+)?(?<after> && .*)?$");
+    private static final Pattern isMakeCommand = Pattern.compile("^(?<before>env CODEOCEAN=true /bin/bash -c \\\"(.* && )?)make(?:\\s+(?<startRule>\\w*))?(?<assignments>(?:.*?=.*?)+)?(?<after>( && .*)?\\\")$");
 
     // This pattern identifies the rules in a makefile.
     private static final Pattern makeRules = Pattern.compile("(?<name>.*):\\r?\\n(?<commands>(?:\\t.+\\r?\\n?)*)");
@@ -110,7 +110,12 @@ class SimpleMakefile {
         if (firstPart) {
             return parts[0];
         } else {
-            return parts[1].replaceAll("^\\\"|\\\"$", "");
+            String value = parts[1];
+            // First, remove one level of escaping: \"HelloWorldTest\" -> "HelloWorldTest"
+            value = value.replaceAll("\\\\\"", "\"");
+            // Then, remove the quotes at the beginning and end of string: "HelloWorldTest" -> HelloWorldTest
+            value = value.replaceAll("^\"|\"$", "");
+            return value;
         }
     }
 

--- a/deploy/aws/java11Exec/src/test/java/poseidon/AppTest.java
+++ b/deploy/aws/java11Exec/src/test/java/poseidon/AppTest.java
@@ -89,7 +89,7 @@ public class AppTest {
   public void makefileJustReplacesShellCommand() {
     ByteArrayOutputStream out = setupStdOutLogs();
     APIGatewayProxyResponseEvent result = getApiGatewayProxyResponse("{\"action\":\"java11Exec\"," +
-            "\"cmd\":[\"env\", \"TEST_VAR=42\", \"sh\",\"-c\",\"make run\"]," +
+            "\"cmd\":[\"env\", \"TEST_VAR=42\", \"sh\",\"-c\",\"env CODEOCEAN=true /bin/bash -c \\\"make run\\\"\"]," +
             "\"files\":{\"Makefile\":\"" + Base64.getEncoder().encodeToString(("run:\n\t@echo $TEST_VAR\n").getBytes(StandardCharsets.UTF_8)) + "\"}}");
     restoreStdOutLogs();
 

--- a/deploy/aws/java11Exec/src/test/java/poseidon/SimpleMakefileTest.java
+++ b/deploy/aws/java11Exec/src/test/java/poseidon/SimpleMakefileTest.java
@@ -83,17 +83,21 @@ public class SimpleMakefileTest {
     parseRunCommandOfMakefile(SuccessfulMakefileWithComment);
   }
 
+  private String wrapFullCommand(String command) {
+    return "env CODEOCEAN=true /bin/bash -c \"" + command + "\"";
+  }
+
   private void parseRunCommandOfMakefile(String makefileB64) {
     Map<String, String> files = new HashMap<>();
     files.put("Makefile", makefileB64);
     files.put("org/example/RecursiveMath.java", RecursiveMathContent);
 
     try {
-      String command = "make run";
+      String command = wrapFullCommand("make run");
       SimpleMakefile makefile = new SimpleMakefile(files);
       String cmd = makefile.parseCommand(command);
 
-      assertEquals("javac org/example/RecursiveMath.java && java org/example/RecursiveMath", cmd);
+      assertEquals(wrapFullCommand("javac org/example/RecursiveMath.java && java org/example/RecursiveMath"), cmd);
     } catch (NoMakefileFoundException | InvalidMakefileException | NoMakeCommandException ignored) {
       fail();
     }
@@ -122,12 +126,12 @@ public class SimpleMakefileTest {
     files.put("org/example/RecursiveMath.java", RecursiveMathContent);
 
     try {
-      String command = "make test CLASS_NAME=\"RecursiveMath\" FILENAME=\"RecursiveMath-Test.java\"";
+      String command = wrapFullCommand("make test CLASS_NAME=\"RecursiveMath\" FILENAME=\"RecursiveMath-Test.java\"");
       SimpleMakefile make = new SimpleMakefile(files);
       String cmd = make.parseCommand(command);
 
-      assertEquals("javac -encoding utf8 RecursiveMath-Test.java && " +
-              "java -Dfile.encoding=UTF8 RecursiveMath", cmd);
+      assertEquals(wrapFullCommand("javac -encoding utf8 RecursiveMath-Test.java && " +
+              "java -Dfile.encoding=UTF8 RecursiveMath"), cmd);
     } catch (NoMakefileFoundException | InvalidMakefileException | NoMakeCommandException ignored) {
       fail();
     }
@@ -140,7 +144,7 @@ public class SimpleMakefileTest {
     files.put("org/example/RecursiveMath.java", RecursiveMathContent);
 
     try {
-      String command = "make run";
+      String command = wrapFullCommand("make run");
       SimpleMakefile makefile = new SimpleMakefile(files);
       makefile.parseCommand(command);
       fail();
@@ -155,11 +159,11 @@ public class SimpleMakefileTest {
     files.put("Makefile", Base64.getEncoder().encodeToString(("run:\n\t@echo TRAAAIIN\n").getBytes(StandardCharsets.UTF_8)));
 
     try {
-      String command = "echo \"Look it's a\" && sl && make run && echo WOW";
+      String command = wrapFullCommand("echo \"Look it's a\" && sl && make run && echo WOW");
       SimpleMakefile makefile = new SimpleMakefile(files);
       String cmd = makefile.parseCommand(command);
 
-      assertEquals("echo \"Look it's a\" && sl && echo TRAAAIIN && echo WOW", cmd);
+      assertEquals(wrapFullCommand("echo \"Look it's a\" && sl && echo TRAAAIIN && echo WOW"), cmd);
     } catch (NoMakefileFoundException | InvalidMakefileException | NoMakeCommandException ignored) {
       fail();
     }


### PR DESCRIPTION
Previously, a command such as the following would fail due to the additional quotes used:

```shell
env CODEOCEAN=true /bin/bash -c "unset \"\${!AWS@}\" && make test CLASS_NAME=\"HalloWeltTest2\" FILENAME=\"HalloWeltTest2.java\""
```