### PR TITLE
AWS: Fix CLASSPATH to prevent NULL entry

### DIFF
--- a/deploy/aws/java11Exec/src/main/java/poseidon/App.java
+++ b/deploy/aws/java11Exec/src/main/java/poseidon/App.java
@@ -96,7 +96,11 @@ public class App implements RequestHandler<APIGatewayV2WebSocketEvent, APIGatewa
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.directory(workingDirectory);
             Map<String, String> env = pb.environment();
-            env.put("CLASSPATH", ".:/var/task/lib/org.hamcrest.hamcrest-3.0.jar:/var/task/lib/junit.junit-4.13.2.jar:" + env.get("CLASSPATH"));
+            if (env.containsKey("CLASSPATH")) {
+                env.put("CLASSPATH", ".:/var/task/lib/org.hamcrest.hamcrest-3.0.jar:/var/task/lib/junit.junit-4.13.2.jar:" + env.get("CLASSPATH"));
+            } else {
+                env.put("CLASSPATH", ".:/var/task/lib/org.hamcrest.hamcrest-3.0.jar:/var/task/lib/junit.junit-4.13.2.jar");
+            }
             Process p = pb.start();
             InputStream stdout = p.getInputStream(), stderr = p.getErrorStream();
             this.forwardOutput(p, stdout, stderr);


### PR DESCRIPTION
Since the `CLASSPATH` is not set already, the previous solution created the following path:

```java
".:/var/task/lib/org.hamcrest.hamcrest-3.0.jar:/var/task/lib/junit.junit-4.13.2.jar:null"
```

Now, we create the following:

```java
".:/var/task/lib/org.hamcrest.hamcrest-3.0.jar:/var/task/lib/junit.junit-4.13.2.jar"
```