### PR TITLE
Remove unrelated Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deploy/codeocean-terraform"]
-	path = deploy/codeocean-terraform
-	url = git@lab.xikolo.de:codeocean/codeocean-terraform.git


### PR DESCRIPTION
Since no file from codeocean-terraform is directly needed, we decided to remove the Git submodule at all.