### PR TITLE
Update AWS SDK to v2

### DIFF
--- a/deploy/aws/java11Exec/pom.xml
+++ b/deploy/aws/java11Exec/pom.xml
@@ -19,9 +19,14 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-apigatewaymanagementapi</artifactId>
-            <version>1.12.772</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apigatewaymanagementapi</artifactId>
+            <version>2.28.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.24.0</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/deploy/aws/java11Exec/src/main/java/resources/log4j2.xml
+++ b/deploy/aws/java11Exec/src/main/java/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN"/>
+        <Logger name="software.amazon.awssdk.request" level="DEBUG"/>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
The previous SDK used has been deprecated. As part of this change, we also need to include Log4J explicitly.

https://aws.amazon.com/de/blogs/developer/the-aws-sdk-for-java-1-x-is-in-maintenance-mode-effective-july-31-2024/