### PR TITLE
Fix flaky TestNomadRunnerManager_Load unit test

### DIFF
--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -656,6 +656,7 @@ func (s *MainTestSuite) TestNomadRunnerManager_Load() {
 		}
 
 		cancelExecution()
+		<-time.After(tests.ShortTimeout)
 		err = r.Destroy(ErrLocalDestruction)
 		s.Require().NoError(err)
 	})


### PR DESCRIPTION
by giving Poseidon more time to cancel the execution before destroying the runner.

Closes #692