### PR TITLE
Fix provideRunner with no managers enabled.

### DIFF
--- a/internal/api/environments.go
+++ b/internal/api/environments.go
@@ -128,6 +128,7 @@ func (e *EnvironmentController) createOrUpdate(writer http.ResponseWriter, reque
 	})
 	if err != nil {
 		writeInternalServerError(request.Context(), writer, err, dto.ErrorUnknown)
+		return
 	}
 
 	if created {

--- a/internal/environment/abstract_manager.go
+++ b/internal/environment/abstract_manager.go
@@ -15,6 +15,14 @@ type AbstractManager struct {
 	runnerManager runner.Manager
 }
 
+// NewAbstractManager creates a new abstract runner manager that keeps track of all environments of one kind.
+func NewAbstractManager(runnerManager runner.Manager) *AbstractManager {
+	return &AbstractManager{
+		nextHandler:   nil,
+		runnerManager: runnerManager,
+	}
+}
+
 func (n *AbstractManager) SetNextHandler(next ManagerHandler) {
 	n.nextHandler = next
 }

--- a/internal/environment/abstract_manager.go
+++ b/internal/environment/abstract_manager.go
@@ -49,7 +49,7 @@ func (n *AbstractManager) Get(_ context.Context, _ dto.EnvironmentID, _ bool) (r
 func (n *AbstractManager) CreateOrUpdate(_ context.Context, _ dto.EnvironmentID, _ dto.ExecutionEnvironmentRequest) (
 	bool, error,
 ) {
-	return false, nil
+	return false, dto.ErrNotSupported
 }
 
 func (n *AbstractManager) Delete(environmentID dto.EnvironmentID) (bool, error) {

--- a/internal/runner/abstract_manager.go
+++ b/internal/runner/abstract_manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openHPI/poseidon/pkg/storage"
 )
 
-var ErrNullObject = errors.New("functionality not available for the null object")
+var ErrUnknownExecutionEnvironment = errors.New("execution environment not found")
 
 // AbstractManager is used to have a fallback runner manager in the chain of responsibility
 // following the null object pattern.
@@ -99,7 +99,7 @@ func (n *AbstractManager) EnvironmentStatistics() map[dto.EnvironmentID]*dto.Sta
 }
 
 func (n *AbstractManager) Claim(_ dto.EnvironmentID, _ int) (Runner, error) {
-	return nil, ErrNullObject
+	return nil, ErrUnknownExecutionEnvironment
 }
 
 func (n *AbstractManager) Get(runnerID string) (Runner, error) {

--- a/internal/runner/nomad_manager_test.go
+++ b/internal/runner/nomad_manager_test.go
@@ -117,7 +117,7 @@ func (s *ManagerTestSuite) TestSetEnvironmentAddsNewEnvironment() {
 func (s *ManagerTestSuite) TestClaimReturnsNotFoundErrorIfEnvironmentNotFound() {
 	runner, err := s.nomadRunnerManager.Claim(anotherEnvironmentID, defaultInactivityTimeout)
 	s.Nil(runner)
-	s.Equal(ErrUnknownExecutionEnvironment, err)
+	s.ErrorIs(err, ErrUnknownExecutionEnvironment)
 }
 
 func (s *ManagerTestSuite) TestClaimReturnsRunnerIfAvailable() {


### PR DESCRIPTION
If only AWS was enabled, a 500 error instead of a 404 error was returned. If both Nomad and AWS was disabled, the requests returned with a 200 response but an empty body. A silent nil-dereference was triggered.

Closes https://github.com/orgs/openHPI/projects/4/views/1?pane=issue&itemId=81052193