### PR TITLE
Limit Java CI to relevant changes

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -3,8 +3,10 @@ name: Java CI
 on:
   push:
     branches: [ main ]
+    paths: [ deploy/aws/** ]
   pull_request:
     branches: [ main ]
+    paths: [ deploy/aws/** ]
 
 jobs:
   test:


### PR DESCRIPTION
Similar to the Python CI, we only want to execute tests when a corresponding file changed. This will save unnecessary resources.