### PR TITLE
Unify spelling of systemd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Run e2e recovery tests
         run: make e2e-test-recovery
         if: ${{ success() || failure() }}
-      - name: Print Systemd Failure logs
+      - name: Print systemd Failure logs
         run: |
           /usr/bin/systemctl --user show poseidon.service -p NRestarts
           journalctl --user -xe -u poseidon.service --no-pager

--- a/.github/workflows/resources/poseidon-minimal.service
+++ b/.github/workflows/resources/poseidon-minimal.service
@@ -1,5 +1,5 @@
 # This is a minimal service definition to make use of the systemd socket activation in the e2e tests.
-# With Systemd socket activation, systemd sets up a listening socket on behalf of a service.
+# With systemd socket activation, systemd sets up a listening socket on behalf of a service.
 # This is useful for zero downtime deployments as the systemd sockets hold up the connections while the service is restarting.
 
 [Unit]

--- a/configuration.example.yaml
+++ b/configuration.example.yaml
@@ -5,7 +5,7 @@ server:
   address: 127.0.0.1
   # Port on which the webserver listens
   port: 7200
-  # When using Systemd socket activation, Poseidon tries to connect to an existing systemd socket instead of creating its own.
+  # When using systemd socket activation, Poseidon tries to connect to an existing systemd socket instead of creating its own.
   # This is useful for zero downtime deployments as the systemd sockets hold up the connections while Poseidon is restarting.
   # Iff systemdsocketactivation, the configured address and port will not be used, instead the provided systemd socket will be.
   systemdsocketactivation: false
@@ -25,7 +25,7 @@ server:
   interactivestderr: true
   # If set, the file at the given path overwrites the default Nomad job file in internal/environment/template-environment-job.hcl
   # templatejobfile: ./poseidon.hcl
-  # The LoggingFilterToken filters out Systemd Watchdog requests from the logs and is preconfigured with a random value.
+  # The LoggingFilterToken filters out systemd Watchdog requests from the logs and is preconfigured with a random value.
   # It can also be manually configured to hide additional requests from the logs, such as those from monitoring systems.
   # To use this feature, the respective user agent must be set according to `dto.UserAgentFiltered`.
   # However, it is important to consider the security implications of using this expert-level setting for manual values.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ If a value is not specified, the value of the subsequent possibility is used.
 
 - Again, this can be overwritten by the environment variable `POSEIDON_SERVER_PORT`, e.g., using `export POSEIDON_SERVER_PORT=5000`.
 
-### Systemd
+### systemd
 
 Poseidon can be configured to run as a systemd service. Poseidon can optionally also be configured to use a systemd socket.
 The use of systemd provides capabilities for managing Poseidon's state and zero downtime deployments.

--- a/docs/nomad_usage.md
+++ b/docs/nomad_usage.md
@@ -60,7 +60,7 @@ In the case of Nomad Agent restarts, the WebSocket connection of a running execu
 Furthermore, when also Docker of the Nomad Agent is restarted, the containers are recreated.
 Poseidon captures such occurrences and uses the runner as clean and idle.
 
-### Systemd Relationship Nomad - Docker
+### systemd Relationship Nomad - Docker
 
 We suggest to connect the Nomad and Docker systemd services through a systemd `PartOf` relationship.
 In a systemd overwrite (`/etc/systemd/system/nomad.service.d/override.conf`), the `PartOf` relationship can be defined as follows:


### PR DESCRIPTION
As systemd is a fixed term, we stick to the official spelling with a lowercase s.