### PR TITLE
Disable automatic refresh for Poseidon autogen dashboard

### DIFF
--- a/deploy/grafana-dashboard/panels/poseidon.dashboard.py
+++ b/deploy/grafana-dashboard/panels/poseidon.dashboard.py
@@ -11,7 +11,7 @@ dashboard = Dashboard(
     panels=availability_panels + general_panels + runner_insights_panels,
     templating=Templating(list=[ environment_variable ]),
     editable=True,
-    refresh="30s",
+    refresh="off",
     time=Time("now-6h", "now"),
     uid="P21Bh1SVk",
     version=1,


### PR DESCRIPTION
Some of the metrics displayed are very compute-intensive. Hence, it is better to disable the automatic refresh and let the use refresh the dashboard upon request.